### PR TITLE
Remove BOOST_AUTO_TEST_CASE from depth tests to prevent ctest parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 build
+Testing
 libraries/pack/gen
 
 *.pyc

--- a/tests/tests/binary_pack_test.cpp
+++ b/tests/tests/binary_pack_test.cpp
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE( reflect_test )
 }
 
 /*
-BOOST_AUTO_TEST_CASE( depth_test )
+( depth_test )
 {
    // The compiler is not happy about the template deduction I am about to make it do,
    // but it will complete it...

--- a/tests/tests/json_pack_test.cpp
+++ b/tests/tests/json_pack_test.cpp
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE( reflect_test )
 }
 
 /*
-BOOST_AUTO_TEST_CASE( depth_test )
+( depth_test )
 {
    // The compiler is not happy about the template deduction I am about to make it do,
    // but it will complete it...


### PR DESCRIPTION
Closes #9