### PR TITLE
Use boost static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas" )
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
 
+set(Boost_USE_STATIC_LIBS ON)
 set(Boost_NO_BOOST_CMAKE ON)
 if( NOT( Boost_VERSION LESS 106900 ) )
    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")

--- a/libraries/log/CMakeLists.txt
+++ b/libraries/log/CMakeLists.txt
@@ -9,4 +9,3 @@ add_library(koinos_log
 
 target_include_directories(koinos_log PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(koinos_log PUBLIC Boost::log_setup Boost::log Boost::filesystem)
-target_compile_definitions(koinos_log PUBLIC -DBOOST_LOG_DYN_LINK)


### PR DESCRIPTION
The first time we call `cmake` and `make` the boost libraries that are found are dynamic. After modifying a `CMakeLists.txt` and re-running `make` it finds static boost libraries. Since boost log needs a special flag when linking dynamically `-D BOOST_LOG_DYN_LINK`, this breaks the build. The PR here uses statically linked boost libraries and removes the compile flag thus working in both cases.

This may not be a permanent solution but it does alleviate the pain points for the time being.