### PR TITLE
Add ccache to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: c++
 
+cache:
+- ccache
+- pip
+
 jobs:
   include:
+    - os: osx
+      osx_image: xcode11.3
+      compiler: clang
+      env: RUN_TYPE=coverage
     - os: linux
       dist: bionic
       compiler: gcc
@@ -10,10 +18,7 @@ jobs:
       osx_image: xcode11.3
       compiler: clang
       env: RUN_TYPE=test
-    - os: osx
-      osx_image: xcode11.3
-      compiler: clang
-      env: RUN_TYPE=coverage
+
 
 before_install:
   - ci/before_install.sh
@@ -31,4 +36,3 @@ notifications:
   slack:
     secure: HYp3mDmCvtrCBjmw+jH4XGVHpYxOZ6O7jXFOM6/QyNDGKZoQaAKr4ZvArtsr5FcnwDi9eVaEyKDwtNpZiUxtFYLO7icejqtW0ibbmDwUTHBAln3vjJnBAwqu0RgloRMLgunJ1M91wnszUoPxSCfeR4xVUtnVl0HbQTaqHc0Z01OBUS1DB9NI+hbb/IkOADBCF7D4T3PubjcWLHdhqGyBtIuwVQ3PEwEMq/4FrGScJnVAp1mDNW2C0StbIJGPetpxCEAIFOsGfdAHF7eNJSkPn6xsjcDlXTp9QX2XgVPOTUILFDn5Eddi+TZM3BMx3keG+vTL6tfLr4d/da13HwcvPbYlowVAfvwV/OsEYskRJ8qNERKg/VAi8m4xdFq8AeE2XLSM8kZyiLb9ki2Ifv+t/Tvp2tZ8qCZlbgsTdCTdILKAKWka0tNwPPDLfG3mHYbFZE4K8rRUTDI2e7b39UpbTRA1qNcrqkP8oQRuvORcKan8JohPPWjuf+XCaP2eteEjyqu60MkhCQ+CSpcocyz4ROLKwAYA2FVhqhIFIxB6fpwivVGxgl/OM1LIcMQEnrDIcZxyaaiICMQHFCBqNLOhI6lOr6XSnJaz0bDK/jFM89vm9vSFlYQ/pMYVE8prfjaXR9ITkC5eOTZMaYnX8sIemK1MC+hpyMnCHsY5fB1HW/A=
     on_success: never
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 
 cmake_minimum_required (VERSION 3.10.2)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+   set(CMAKE_XCODE_ATTRIBUTE_CC           "${CMAKE_SOURCE_DIR}/ci/ccache_clang")
+   set(CMAKE_XCODE_ATTRIBUTE_CXX          "${CMAKE_SOURCE_DIR}/ci/ccache_clang++")
+   set(CMAKE_XCODE_ATTRIBUTE_LD           "${CMAKE_SOURCE_DIR}/ci/ccache_clang")
+   set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS   "${CMAKE_SOURCE_DIR}/ci/ccache_clang++")
+endif()
+
 project( koinos )
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -4,10 +4,11 @@ set -e
 set -x
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-   export OPENSSL_ROOT_DIR=$(brew --cellar openssl)/$(brew list --versions openssl | tr ' ' '\n' | tail -1)
-   export SNAPPY_LIBRARIES=$(brew --cellar snappy)/$(brew list --versions snappy | tr ' ' '\n' | tail -1)/lib
-   export SNAPPY_INCLUDE_DIR=$(brew --cellar snappy)/$(brew list --versions snappy | tr ' ' '\n' | tail -1)/include
-   export ZLIB_LIBRARIES=$(brew --cellar zlib)/$(brew list --versions zlib | tr ' ' '\n' | tail -1)/lib
+   PACKAGE_DIR=/usr/local/opt
+   export OPENSSL_ROOT_DIR=${PACKAGE_DIR}/openssl@1.1
+   export SNAPPY_LIBRARIES=${PACKAGE_DIR}/snappy/lib
+   export SNAPPY_INCLUDE_DIR=${PACKAGE_DIR}/snappy/include
+   export ZLIB_LIBRARIES=${PACKAGE_DIR}/zlib/lib
 fi
 
 mkdir build

--- a/ci/ccache_clang
+++ b/ci/ccache_clang
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ccache clang "$@"

--- a/ci/ccache_clang++
+++ b/ci/ccache_clang++
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ccache clang++ "$@"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -12,7 +12,8 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       libbz2-dev \
       liblz4-dev \
       libzstd-dev \
-      valgrind
+      valgrind \
+      ccache
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
    brew install cmake \
       boost \
@@ -20,7 +21,8 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
       zlib \
       snappy \
       bzip2 \
-      gflags
+      gflags \
+      ccache
 
    if [ "$RUN_TYPE" = "coverage" ]; then
       brew install lcov


### PR DESCRIPTION
This adds ccache to CI builds as well as local builds if devs want to use it.

With ccache, wall clock time for CI is reduced to ~22 minutes and total build time to ~28 minutes compared to 54 minutes and 88 minutes on `master` respectively for an effective speed up of 145% under optimal conditions.