### PR TITLE
Add "koinosd startup complete" message

### DIFF
--- a/programs/koinosd/main.cpp
+++ b/programs/koinosd/main.cpp
@@ -68,6 +68,7 @@ int main( int argc, char** argv )
          LOG(info) << msg;
       });
       appbase::app().startup();
+      LOG(info) << "koinosd startup complete";
       appbase::app().exec();
       LOG(info) << "exited cleanly";
 


### PR DESCRIPTION
This message helps reading the logs, but its main purpose is for cluster startup sequencing (i.e., a script can monitor for this message to kick off a dependent service like p2p)
