### PR TITLE
Fix get_fork_heads

### DIFF
--- a/libraries/plugins/chain/reqhandler.cpp
+++ b/libraries/plugins/chain/reqhandler.cpp
@@ -530,7 +530,7 @@ void reqhandler_impl::process_submission( types::rpc::get_fork_heads_submission_
 
    if( subret_hi.height == 0 )
    {
-      ret.fork_heads.resize(0);
+      ret.fork_heads.clear();
    }
    else
    {


### PR DESCRIPTION
P2P integration testing revealed a couple bugs in `get_fork_heads`, that are fixed by this PR.

- Mutability bug:  Properly unbox `query_item_result` as `const` to avoid a runtime error
- Genesis case:  If we don't have any blocks, zero fork heads should be returned.