### PR TITLE
Change create_directory -> create_directories

### DIFF
--- a/programs/koinos_chain/main.cpp
+++ b/programs/koinos_chain/main.cpp
@@ -396,7 +396,7 @@ int main( int argc, char** argv )
          statedir = basedir / "chain" / statedir;
 
       if ( !filesystem::exists( statedir ) )
-         filesystem::create_directory( statedir );
+         filesystem::create_directories( statedir );
 
       auto database_config_path = filesystem::path( args[ DATABASE_CONFIG_OPTION ].as< std::string >() );
 


### PR DESCRIPTION

I discovered that `koinos-chain` fails to create the `blockchain` directory when running with no parameters on a brand-new machine.

With this patch, we'll use `create_directories`, so any non-existing parent directories will be created as well.  This fixes the issue.