### PR TITLE
Reversion error message (v0.3.x)

### DIFF
--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -514,8 +514,14 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
       {
          // If the transaction fails for any other reason within the operations, it is reverted.
          // Mana is still charged, but the block does not fail
-         LOG(info) << "Transaction " << util::to_hex( trx.id() ) << " reverted with: " << e.what();
-         reverted_exception_ptr = std::make_unique< transaction_reverted >( e.what() );
+         std::string err = e.what();
+
+         if ( err.size() )
+            LOG(info) << "Transaction " << util::to_hex( trx.id() ) << " reverted with: " << err;
+         else
+            LOG(info) << "Transaction " << util::to_hex( trx.id() ) << " reverted";
+
+         reverted_exception_ptr = std::make_unique< transaction_reverted >( err.size() ? err : "transaction reverted" );
          receipt.set_reverted( true );
       }
 

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -516,12 +516,17 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
          // Mana is still charged, but the block does not fail
          std::string err = e.what();
 
-         if ( err.size() )
+         if ( !err.empty() )
+         {
             LOG(info) << "Transaction " << util::to_hex( trx.id() ) << " reverted with: " << err;
+         }
          else
+         {
             LOG(info) << "Transaction " << util::to_hex( trx.id() ) << " reverted";
+            err = "transaction reverted";
+         }
 
-         reverted_exception_ptr = std::make_unique< transaction_reverted >( err.size() ? err : "transaction reverted" );
+         reverted_exception_ptr = std::make_unique< transaction_reverted >( err );
          receipt.set_reverted( true );
       }
 


### PR DESCRIPTION
Resolves #641.

## Brief description
Ensure that the exception has an error message when transactions are reverted.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "transaction reverted",
    "data": "{\"logs\":[\"lib: INSUFFICIENT_B_AMOUNT\"]}"
  },
  "id": 1
}
```
