### PR TITLE
Logs on reversion

### DIFF
--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -553,9 +553,9 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
       network_bandwidth_used = context.resource_meter().network_bandwidth_used() - start_network_used;
       compute_bandwidth_used = context.resource_meter().compute_bandwidth_used() - start_compute_used;
 
-      // END: No throw section
-
       payer_session.reset();
+
+      // END: No throw section
 
       KOINOS_ASSERT_FAILURE(
          system_call::consume_account_rc( context, payer, used_rc ),

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -472,6 +472,8 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
             "invalid transaction nonce - account: ${a}, nonce: ${n}, current nonce: ${c}",
             ("a", util::to_base58( nonce_account ))("n", util::to_hex( trx.header().nonce() ))("c", util::to_hex( system_call::get_account_nonce( context, nonce_account) ))
          );
+
+         system_call::set_account_nonce( context, nonce_account, trx.header().nonce() );
       }
       catch ( const chain_reversion& e )
       {
@@ -539,9 +541,10 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
          throw;
       }
 
-      context.set_state_node( block_node );
+      // BEGIN: No throw section
+      // Throwing will result in lost events and logs on transaction receipts.
 
-      system_call::set_account_nonce( context, nonce_account, trx.header().nonce() );
+      context.set_state_node( block_node );
 
       used_rc = payer_session->used_rc();
       events = payer_session->events();
@@ -549,6 +552,8 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
       disk_storage_used = context.resource_meter().disk_storage_used() - start_disk_used;
       network_bandwidth_used = context.resource_meter().network_bandwidth_used() - start_network_used;
       compute_bandwidth_used = context.resource_meter().compute_bandwidth_used() - start_compute_used;
+
+      // END: No throw section
 
       payer_session.reset();
 


### PR DESCRIPTION
Resolves #662
## Brief description
Call `set_account_nonce` prior to executing the transaction. Using comments, make clear the section that throws should be avoided.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
Creating hello contract upload operation
Creating forever contract upload operation
Creating operation that calls both contracts
Constructing block
Submitting block
2022-05-10 15:36:36.022029 (koinos_test.WRB0J) [controller.cpp:253] <info>: Pushing block - Height: 2, ID: 0x122071e4f1d225fc020866e5303dc28922780879030adc9a1ccc9025b9f898799d36
2022-05-10 15:36:36.193767 (koinos_test.WRB0J) [system_calls.cpp:386] <info>: Transaction 0x12204413ebc575b7433ae33a63d8af1feb5126250163028c28b62add068b95c3a315 reverted with: insufficent rc
2022-05-10 15:36:36.194501 (koinos_test.WRB0J) [controller.cpp:337] <info>: Block application successful - Height: 2, ID: 0x122071e4f1d225fc020866e5303dc28922780879030adc9a1ccc9025b9f898799d36 (3 transactions)
2022-05-10 15:36:36.194575 (koinos_test.WRB0J) [controller.cpp:338] <info>: Consumed resources: 214 disk, 1503 network, 10488077 compute
Ensuring transaction(0) succeeded
Ensuring transaction(1) succeeded
Ensuring transaction(2) was reverted and the log still exists on the receipt
```
