### PR TITLE
RPC error code

### DIFF
--- a/programs/koinos_chain/main.cpp
+++ b/programs/koinos_chain/main.cpp
@@ -366,18 +366,35 @@ void attach_request_handler(
             }
             catch( std::exception& e )
             {
-               resp.mutable_error()->set_message( e.what() );
+               auto error = resp.mutable_error();
+               error->set_message( e.what() );
+
+               nlohmann::json j;
+               j[ "code" ] = chain::internal_error;
+               error->set_data( j.dump() );
             }
             catch( ... )
             {
                LOG(error) << "Unexpected error while handling rpc: " << args.ShortDebugString();
-               resp.mutable_error()->set_message( "Unexpected error while handling rpc" );
+
+               auto error = resp.mutable_error();
+               error->set_message( "unexpected error while handling rpc" );
+
+               nlohmann::json j;
+               j[ "code" ] = chain::internal_error;
+               error->set_data( j.dump() );
             }
          }
          else
          {
             LOG(warning) << "Received bad message";
-            resp.mutable_error()->set_message( "Received bad message" );
+
+            auto error = resp.mutable_error();
+            error->set_message( "received bad message" );
+
+            nlohmann::json j;
+            j[ "code" ] = chain::internal_error;
+            error->set_data( j.dump() );
          }
 
          LOG(debug) << "Sending RPC response: " << resp;

--- a/programs/koinos_chain/main.cpp
+++ b/programs/koinos_chain/main.cpp
@@ -359,7 +359,10 @@ void attach_request_handler(
             {
                auto error = resp.mutable_error();
                error->set_message( e.what() );
-               error->set_data( e.get_json().dump() );
+
+               auto j = e.get_json();
+               j[ "code" ] = e.get_code();
+               error->set_data( j.dump() );
             }
             catch( std::exception& e )
             {


### PR DESCRIPTION
Resolves #667.

## Brief description
Add `code` to RPC response JSON data.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```console
❯ curl -d '{"jsonrpc":"2.0", "method":"chain.read_contract", "params":{"args":"","contract_id":"z11111111111111111112","entry_point":1249216561}, "id":1}' http://localhost:8080/
{"jsonrpc":"2.0","error":{"code":-32603,"message":"contract does not exist","data":"{\"code\":102}"},"id":1}
```

```proto
...
    invalid_contract             =  102;
...
```
