### PR TITLE
Check Error Codes in Tests

### DIFF
--- a/tests/include/koinos/tests/util.hpp
+++ b/tests/include/koinos/tests/util.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#define KOINOS_CHECK_THROW( S, C )                                      \
+do                                                                      \
+{                                                                       \
+   try                                                                  \
+   {                                                                    \
+      S;                                                                \
+      BOOST_TEST(false, "koinos::exception not thrown when expected" ); \
+   }                                                                    \
+   catch ( const koinos::exception& e )                                 \
+   {                                                                    \
+      BOOST_TEST_REQUIRE( e.get_code() == C, "exception code is not " #C ", was " + std::to_string( e.get_code() ) ); \
+   }                                                                    \
+} while( 0 );
+
+#define KOINOS_REQUIRE_THROW( S, C )                                             \
+do                                                                               \
+{                                                                                \
+   try                                                                           \
+   {                                                                             \
+      S;                                                                         \
+      BOOST_TEST_REQUIRE(false, "koinos::exception not thrown when expected" );  \
+   }                                                                             \
+   catch ( const koinos::exception& e )                                          \
+   {                                                                             \
+      BOOST_TEST_REQUIRE( e.get_code() == C, "exception code is not " #C ", was " + std::to_string( e.get_code() ) ); \
+   }                                                                             \
+} while( 0 );

--- a/tests/tests/controller_test.cpp
+++ b/tests/tests/controller_test.cpp
@@ -14,6 +14,7 @@
 #include <koinos/util/base58.hpp>
 
 #include <koinos/tests/contracts.hpp>
+#include <koinos/tests/util.hpp>
 
 #include <koinos/contracts/token/token.pb.h>
 
@@ -266,7 +267,7 @@ BOOST_AUTO_TEST_CASE( submission_tests )
 
    sign_block( *block_req.mutable_block(), foo_key );
 
-   BOOST_CHECK_THROW( _controller.submit_block( block_req ), chain::invalid_signature_exception );
+   KOINOS_CHECK_THROW( _controller.submit_block( block_req ), chain::invalid_signature );
 
    BOOST_TEST_MESSAGE( "Error when previous block does not match" );
 
@@ -586,15 +587,7 @@ BOOST_AUTO_TEST_CASE( read_contract_tests )
    BOOST_TEST_MESSAGE( "Test read contract db write" );
 
    request.set_contract_id( util::converter::as< std::string >( key3.get_public_key().to_address_bytes() ) );
-   try
-   {
-      _controller.read_contract( request );
-      BOOST_FAIL( "expected reversion_exception not thrown" );
-   }
-   catch ( const chain::reversion_exception& e )
-   {
-      BOOST_REQUIRE_EQUAL( e.get_code(), chain::read_only_context );
-   }
+   KOINOS_REQUIRE_THROW( _controller.read_contract( request ), chain::read_only_context );
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
 BOOST_AUTO_TEST_CASE( transaction_reversion_test )

--- a/tests/tests/stack_test.cpp
+++ b/tests/tests/stack_test.cpp
@@ -13,6 +13,7 @@
 #include <koinos/crypto/elliptic.hpp>
 
 #include <koinos/tests/contracts.hpp>
+#include <koinos/tests/util.hpp>
 
 #include <koinos/util/hex.hpp>
 
@@ -474,7 +475,7 @@ BOOST_AUTO_TEST_CASE( user_from_user )
    sign_transaction( trx, user_key );
 
    ctx.set_transaction( trx );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, trx ), chain::reversion_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, trx ), chain::reversion );
 }
 
 BOOST_AUTO_TEST_CASE( syscall_override_from_thunk )

--- a/tests/tests/thunk_test.cpp
+++ b/tests/tests/thunk_test.cpp
@@ -32,6 +32,7 @@
 #include <koinos/contracts/token/token.pb.h>
 
 #include <koinos/tests/contracts.hpp>
+#include <koinos/tests/util.hpp>
 
 #include <koinos/util/base58.hpp>
 #include <koinos/util/hex.hpp>
@@ -373,13 +374,13 @@ BOOST_AUTO_TEST_CASE( get_transaction_field )
 
    BOOST_TEST_MESSAGE( "Testing dynamic transaction field not found" );
 
-   BOOST_REQUIRE_THROW( chain::system_call::get_transaction_field( ctx, "non_existent_field" ), chain::field_not_found_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::get_transaction_field( ctx, "non_existent_field" ), chain::field_not_found );
 
    ctx.clear_transaction();
 
    BOOST_TEST_MESSAGE( "Testing dynamic transaction field unexpected access" );
 
-   BOOST_REQUIRE_THROW( chain::system_call::get_transaction_field( ctx, "id" ), chain::internal_error_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::get_transaction_field( ctx, "id" ), chain::internal_error );
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
@@ -474,13 +475,13 @@ BOOST_AUTO_TEST_CASE( get_block_field )
 
    BOOST_TEST_MESSAGE( "Testing dynamic block field not found" );
 
-   BOOST_REQUIRE_THROW( chain::system_call::get_block_field( ctx, "non_existent_field" ), chain::field_not_found_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::get_block_field( ctx, "non_existent_field" ), chain::field_not_found );
 
    ctx.clear_block();
 
    BOOST_TEST_MESSAGE( "Testing dynamic block field unexpected access" );
 
-   BOOST_REQUIRE_THROW( chain::system_call::get_block_field( ctx, "id" ), chain::internal_error_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::get_block_field( ctx, "id" ), chain::internal_error );
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
@@ -650,7 +651,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
 
    BOOST_TEST_MESSAGE( "Test failure to override system call without genesis key" );
 
-   BOOST_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::system_authorization_failure_exception );
+   KOINOS_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::system_authorization_failure );
 
    BOOST_TEST_MESSAGE( "Test failure to set system contract without genesis key" );
 
@@ -658,7 +659,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    system_contract_op.set_contract_id( contract_op2.contract_id() );
    system_contract_op.set_system_contract( true );
 
-   BOOST_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_contract_operation( ctx, system_contract_op ), koinos::chain::system_authorization_failure_exception );
+   KOINOS_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_contract_operation( ctx, system_contract_op ), koinos::chain::system_authorization_failure );
 
    BOOST_TEST_MESSAGE( "Test failure to override system call without system contract" );
 
@@ -666,7 +667,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    sign_transaction( tx, _signing_private_key );
    ctx.set_transaction( tx );
 
-   BOOST_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::invalid_contract_exception );
+   KOINOS_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::invalid_contract );
 
    BOOST_TEST_MESSAGE( "Test success overriding a system call with the genesis key" );
 
@@ -686,7 +687,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    // Ensure exception thrown on invalid contract
    auto false_id = koinos::crypto::hash( koinos::crypto::multicodec::ripemd_160, 1234 );
    set_op.mutable_target()->mutable_system_call_bundle()->set_contract_id( util::converter::as< std::string >( false_id ) );
-   BOOST_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::invalid_contract_exception );
+   KOINOS_REQUIRE_THROW( koinos::chain::system_call::apply_set_system_call_operation( ctx, set_op ), koinos::chain::invalid_contract );
 
    // Test invoking the overridden system call
    koinos::chain::system_call::apply_call_contract_operation( ctx, call_op );
@@ -703,7 +704,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    auto args = util::converter::as< std::string >( log_args );
    char ret_buf[100];
    uint32_t bytes_written = 0;
-   BOOST_CHECK_THROW( host.invoke_system_call( 0, ret_buf, 100, args.data(), args.size(), &bytes_written ), chain::unknown_thunk_exception );
+   KOINOS_CHECK_THROW( host.invoke_system_call( 0, ret_buf, 100, args.data(), args.size(), &bytes_written ), chain::unknown_thunk );
 
    BOOST_TEST_MESSAGE( "Test overriding a system call with another thunk" );
 
@@ -713,7 +714,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    ctx.set_state_node( ctx.get_state_node()->create_anonymous_node() );
    ctx.reset_cache();
 
-   BOOST_CHECK_THROW( koinos::chain::system_call::log( host._ctx, "Hello World" ), chain::reversion_exception );
+   KOINOS_CHECK_THROW( koinos::chain::system_call::log( host._ctx, "Hello World" ), chain::reversion );
 
    auto cbr = util::converter::to< chain::compute_bandwidth_registry >( chain::system_call::get_object( ctx, chain::state::space::metadata(), chain::state::key::compute_bandwidth_registry ).value() );
    auto centry = cbr.add_entries();
@@ -728,7 +729,7 @@ BOOST_AUTO_TEST_CASE( override_tests )
    BOOST_REQUIRE_EQUAL( "thunk: Hello World", host._ctx.chronicler().logs()[3] );
 
    host.invoke_system_call( chain::system_call_id::log, ret_buf, 100, args.data(), args.size(), &bytes_written );
-   BOOST_CHECK_THROW( host.invoke_system_call( 0, ret_buf, 100, args.data(), args.size(), &bytes_written ), chain::unknown_thunk_exception );
+   KOINOS_CHECK_THROW( host.invoke_system_call( 0, ret_buf, 100, args.data(), args.size(), &bytes_written ), chain::unknown_thunk );
 
    BOOST_TEST_MESSAGE( "Test enabling new thunk passthrough" );
 
@@ -767,7 +768,7 @@ BOOST_AUTO_TEST_CASE( thunk_test )
    BOOST_REQUIRE_EQUAL( "Hello World", ctx.chronicler().logs()[0] );
 
    ctx.push_frame( chain::stack_frame{ .contract_id = "user_contract", .call_privilege = chain::user_mode } );
-   BOOST_REQUIRE_THROW( host.invoke_thunk( chain::system_call_id::log, ret.data(), ret.size(), arg.data(), arg.size(), &bytes_written ), chain::insufficient_privileges_exception );
+   KOINOS_REQUIRE_THROW( host.invoke_thunk( chain::system_call_id::log, ret.data(), ret.size(), arg.data(), arg.size(), &bytes_written ), chain::insufficient_privileges );
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
 BOOST_AUTO_TEST_CASE( system_call_test )
@@ -839,7 +840,7 @@ BOOST_AUTO_TEST_CASE( hash_thunk_test )
 
    BOOST_CHECK_EQUAL( thunk_hash, native_hash );
 
-   BOOST_REQUIRE_THROW( chain::system_call::hash( ctx, 0xDEADBEEF /* unknown code */, blob ), koinos::chain::unknown_hash_code_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::hash( ctx, 0xDEADBEEF /* unknown code */, blob ), koinos::chain::unknown_hash_code );
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
@@ -847,12 +848,12 @@ BOOST_AUTO_TEST_CASE( privileged_calls )
 {
    ctx.set_privilege( chain::privilege::user_mode );
 
-   BOOST_REQUIRE_THROW( chain::system_call::apply_block( ctx, protocol::block{} ), koinos::chain::insufficient_privileges_exception );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, protocol::transaction() ), koinos::chain::insufficient_privileges_exception );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_upload_contract_operation( ctx, protocol::upload_contract_operation{} ), koinos::chain::insufficient_privileges_exception );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_call_contract_operation( ctx, protocol::call_contract_operation{} ), koinos::chain::insufficient_privileges_exception );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_set_system_call_operation( ctx, protocol::set_system_call_operation{} ), koinos::chain::insufficient_privileges_exception );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_set_system_contract_operation( ctx, protocol::set_system_contract_operation{} ), koinos::chain::insufficient_privileges_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_block( ctx, protocol::block{} ), koinos::chain::insufficient_privileges );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, protocol::transaction() ), koinos::chain::insufficient_privileges );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_upload_contract_operation( ctx, protocol::upload_contract_operation{} ), koinos::chain::insufficient_privileges );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_call_contract_operation( ctx, protocol::call_contract_operation{} ), koinos::chain::insufficient_privileges );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_set_system_call_operation( ctx, protocol::set_system_call_operation{} ), koinos::chain::insufficient_privileges );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_set_system_contract_operation( ctx, protocol::set_system_contract_operation{} ), koinos::chain::insufficient_privileges );
 }
 
 BOOST_AUTO_TEST_CASE( last_irreversible_block_test )
@@ -879,7 +880,7 @@ BOOST_AUTO_TEST_CASE( stack_tests )
    BOOST_TEST_MESSAGE( "apply context stack tests" );
    ctx.pop_frame();
 
-   BOOST_REQUIRE_THROW( ctx.pop_frame(), chain::reversion_exception );
+   KOINOS_REQUIRE_THROW( ctx.pop_frame(), chain::reversion );
 
    auto call1 = util::converter::as< std::string >( crypto::hash( crypto::multicodec::ripemd_160, "call1"s ) );
    ctx.push_frame( chain::stack_frame{ .contract_id = call1 } );
@@ -901,7 +902,7 @@ BOOST_AUTO_TEST_CASE( stack_tests )
       ctx.push_frame( chain::stack_frame{} );
    }
 
-   BOOST_REQUIRE_THROW( ctx.push_frame( chain::stack_frame{} ), chain::reversion_exception );
+   KOINOS_REQUIRE_THROW( ctx.push_frame( chain::stack_frame{} ), chain::reversion );
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
@@ -960,7 +961,7 @@ BOOST_AUTO_TEST_CASE( transaction_nonce_test )
    set_transaction_merkle_roots( transaction, crypto::multicodec::sha2_256 );
    sign_transaction( transaction, key );
 
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::failure_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::invalid_nonce );
 
    nonce = chain::system_call::get_account_nonce( ctx, payer );
    BOOST_REQUIRE_EQUAL( nonce, util::converter::as< std::string >( nonce_value ) );
@@ -981,7 +982,7 @@ BOOST_AUTO_TEST_CASE( transaction_nonce_test )
    set_transaction_merkle_roots( transaction, crypto::multicodec::sha2_256 );
    sign_transaction( transaction, key );
 
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::failure_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::invalid_nonce );
 
    nonce = chain::system_call::get_account_nonce( ctx, payer );
    BOOST_REQUIRE_EQUAL( nonce, util::converter::as< std::string >( nonce_value ) );
@@ -1004,7 +1005,7 @@ BOOST_AUTO_TEST_CASE( transaction_nonce_test )
    set_transaction_merkle_roots( transaction, crypto::multicodec::sha2_256 );
    sign_transaction( transaction, key );
 
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::failure_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::invalid_nonce );
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
 BOOST_AUTO_TEST_CASE( get_contract_id_test )
@@ -1133,24 +1134,21 @@ BOOST_AUTO_TEST_CASE( token_tests )
    transfer_args.set_value( 25 );
 
    ctx.set_transaction( trx );
-   try
-   {
-      session = ctx.make_session( 10'000'000 );
-      koinos::chain::system_call::call( ctx, op.contract_id(), token_entry::transfer, util::converter::as< std::string >( transfer_args ) );
-      BOOST_FAIL( "Expected invalid signature exception" );
-   }
-   catch ( const koinos::chain::reversion_exception& ) {}
+   session = ctx.make_session( 10'000'000 );
+
+   KOINOS_REQUIRE_THROW(
+      koinos::chain::system_call::call( ctx, op.contract_id(), token_entry::transfer, util::converter::as< std::string >( transfer_args ) ),
+      chain::reversion
+   );
 
    sign_transaction( trx, bob_private_key );
    ctx.set_transaction( trx );
+   session = ctx.make_session( 10'000'000 );
 
-   try
-   {
-      session = ctx.make_session( 10'000'000 );
-      koinos::chain::system_call::call( ctx, op.contract_id(), token_entry::transfer, util::converter::as< std::string >( transfer_args ) );
-      BOOST_FAIL( "Expected invalid signature exception" );
-   }
-   catch ( const koinos::chain::reversion_exception& ) {}
+   KOINOS_REQUIRE_THROW(
+      koinos::chain::system_call::call( ctx, op.contract_id(), token_entry::transfer, util::converter::as< std::string >( transfer_args ) ),
+      chain::reversion
+   );
 
    sign_transaction( trx, alice_private_key );
    ctx.set_transaction( trx );
@@ -1218,7 +1216,7 @@ BOOST_AUTO_TEST_CASE( tick_limit )
    auto compute_bandwidth_remaining = ctx.resource_meter().compute_bandwidth_remaining();
 
    auto session = ctx.make_session( 1'000'000 );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_call_contract_operation( ctx, op2 ), chain::insufficient_rc_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_call_contract_operation( ctx, op2 ), chain::insufficient_rc );
    BOOST_REQUIRE_EQUAL( session->used_rc(), 1'000'000 );
    BOOST_REQUIRE_EQUAL( session->remaining_rc(), 0 );
    session.reset();
@@ -1277,7 +1275,7 @@ BOOST_AUTO_TEST_CASE( transaction_reversion )
    ctx.set_intent( chain::intent::transaction_application );
 
    ctx.set_state_node( trx_state_node );
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::reversion_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::invalid_contract );
    db.finalize_node( trx_state_node->id() );
 
    ctx.set_state_node( control_state_node );
@@ -1294,18 +1292,7 @@ BOOST_AUTO_TEST_CASE( transaction_reversion )
    auto failed_trx_state_node = db.create_writable_node( head_state_node->id(), crypto::hash( crypto::multicodec::sha2_256, "failed_trx"s ) );
    ctx.set_state_node( failed_trx_state_node );
 
-   try
-   {
-      chain::system_call::apply_transaction( ctx, transaction );
-      BOOST_FAIL( "expected exception not thrown" );
-   }
-   catch ( chain::reversion_exception& )
-   {
-      BOOST_FAIL( "transaction_reverted exception erroneously thrown" );
-   }
-   catch ( koinos::exception& e ) { /* pass */ }
-
-   BOOST_TEST_MESSAGE( "Submitting failing transaction within a block" );
+   KOINOS_CHECK_THROW( chain::system_call::apply_transaction( ctx, transaction ), chain::failure );
 
    auto parent_node = db.get_node( crypto::multihash::zero( crypto::multicodec::sha2_256 ) );
    protocol::block block;
@@ -1409,16 +1396,10 @@ BOOST_AUTO_TEST_CASE( authorize_tests )
    transfer_args.set_value( 25 );
 
    sign_transaction( trx, key_a );
-
-   try
-   {
-      koinos::chain::system_call::call( ctx, util::converter::as< std::string >( contract_address ), token_entry::transfer, util::converter::as< std::string >( transfer_args ) );
-      BOOST_FAIL( "Expected invalid signature" );
-   }
-   catch ( const koinos::chain::reversion_exception& e )
-   {
-      LOG(info) << e.get_code() << "," << e.get_message();
-   }
+   KOINOS_REQUIRE_THROW(
+      koinos::chain::system_call::call( ctx, util::converter::as< std::string >( contract_address ), token_entry::transfer, util::converter::as< std::string >( transfer_args ) ),
+      chain::reversion
+   );
 
    sign_transaction( trx, key_b );
    koinos::chain::system_call::call( ctx, util::converter::as< std::string >( contract_address ), token_entry::transfer, util::converter::as< std::string >( transfer_args ) );
@@ -1438,9 +1419,9 @@ BOOST_AUTO_TEST_CASE( authorize_tests )
    upload_op.set_authorizes_upload_contract( false );
    upload_op.set_authorizes_transaction_application( true );
 
-   BOOST_REQUIRE_THROW(
+   KOINOS_REQUIRE_THROW(
       koinos::chain::system_call::apply_upload_contract_operation( ctx, upload_op ),
-      chain::authorization_failure_exception );
+      chain::authorization_failure );
 
    sign_transaction( trx, key_b );
    koinos::chain::system_call::apply_upload_contract_operation( ctx, upload_op );
@@ -1462,7 +1443,7 @@ BOOST_AUTO_TEST_CASE( authorize_tests )
    trx.clear_signatures();
    trx.add_signatures( util::converter::as< std::string >( key_a.sign_compact( id_mh ) ) );
 
-   BOOST_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, trx ), chain::failure_exception );
+   KOINOS_REQUIRE_THROW( chain::system_call::apply_transaction( ctx, trx ), chain::authorization_failure );
 
    trx.add_signatures( util::converter::as< std::string >( key_b.sign_compact( id_mh ) ) );
 


### PR DESCRIPTION
Resolves #668

## Brief description

Adds helper macros `KOINOS_CHECK_THROW` and `KOINOS_REQUIRE_THROW` that also check the exception's error code against an expected error code.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
