### PR TITLE
120 key size

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -140,10 +140,12 @@ void controller_impl::open( const std::filesystem::path& p, const chain::genesis
       for ( const auto& entry : data.entries() )
       {
          KOINOS_ASSERT(
-            root->put_object( entry.space(), entry.key(), &entry.value() ) == entry.value().size(),
+            !root->get_object( entry.space(), entry.key() ),
             koinos::chain::unexpected_state,
             "encountered unexpected object in initial state"
          );
+
+         root->put_object( entry.space(), entry.key(), &entry.value() );
       }
       LOG(info) << "Wrote " << data.entries().size() << " genesis objects into new database";
 
@@ -159,10 +161,12 @@ void controller_impl::open( const std::filesystem::path& p, const chain::genesis
       LOG(info) << "Calculated chain ID: " << chain_id;
       auto chain_id_str = util::converter::as< std::string >( chain_id );
       KOINOS_ASSERT(
-         root->put_object( chain::state::space::metadata(), chain::state::key::chain_id, &chain_id_str ) == chain_id_str.size(),
+         !root->get_object( chain::state::space::metadata(), chain::state::key::chain_id ),
          koinos::chain::unexpected_state,
          "encountered unexpected chain id in initial state"
       );
+
+      root->put_object( chain::state::space::metadata(), chain::state::key::chain_id, &chain_id_str );
       LOG(info) << "Wrote chain ID into new database";
    } );
 

--- a/libraries/chain/include/koinos/chain/resource_meter.hpp
+++ b/libraries/chain/include/koinos/chain/resource_meter.hpp
@@ -14,7 +14,7 @@ namespace compute_load {
 
 struct abstract_rc_session
 {
-   virtual void use_rc( uint64_t rc ) = 0;
+   virtual void use_rc( int64_t rc ) = 0;
    virtual uint64_t remaining_rc() = 0;
    virtual uint64_t used_rc() = 0;
 };
@@ -29,15 +29,15 @@ public:
 
    void set_session( std::shared_ptr< abstract_rc_session > s );
 
-   void use_disk_storage( uint64_t bytes );
+   void use_disk_storage( int64_t bytes );
    uint64_t disk_storage_used();
    uint64_t disk_storage_remaining();
 
-   void use_network_bandwidth( uint64_t bytes );
+   void use_network_bandwidth( int64_t bytes );
    uint64_t network_bandwidth_used();
    uint64_t network_bandwidth_remaining();
 
-   void use_compute_bandwidth( uint64_t ticks );
+   void use_compute_bandwidth( int64_t ticks );
    uint64_t compute_bandwidth_used();
    uint64_t compute_bandwidth_remaining();
 

--- a/libraries/chain/include/koinos/chain/session.hpp
+++ b/libraries/chain/include/koinos/chain/session.hpp
@@ -11,10 +11,10 @@ namespace koinos::chain {
 class session final : public abstract_rc_session, public abstract_chronicler_session
 {
 public:
-   session( uint64_t begin_rc );
+   session( int64_t begin_rc );
    ~session();
 
-   virtual void use_rc( uint64_t rc ) override;
+   virtual void use_rc( int64_t rc ) override;
    virtual uint64_t remaining_rc() override;
    virtual uint64_t used_rc() override;
    virtual void push_event( const protocol::event_data& ev ) override;
@@ -24,8 +24,8 @@ public:
    virtual const std::vector< std::string >& logs() override;
 
 private:
-   uint64_t                            _begin_rc;
-   uint64_t                            _end_rc;
+   int64_t                             _begin_rc;
+   int64_t                             _end_rc;
    std::vector< protocol::event_data > _events;
    std::vector< std::string >          _logs;
 };

--- a/libraries/chain/resource_meter.cpp
+++ b/libraries/chain/resource_meter.cpp
@@ -52,6 +52,9 @@ void resource_meter::use_disk_storage( int64_t bytes )
 
 uint64_t resource_meter::disk_storage_used()
 {
+   if ( _disk_storage_remaining > _resource_limit_data.disk_storage_limit() )
+      return 0;
+
    return _resource_limit_data.disk_storage_limit() - _disk_storage_remaining;
 }
 

--- a/libraries/chain/resource_meter.cpp
+++ b/libraries/chain/resource_meter.cpp
@@ -74,7 +74,7 @@ uint64_t resource_meter::disk_storage_remaining()
 void resource_meter::use_network_bandwidth( int64_t bytes )
 {
    KOINOS_ASSERT( bytes <= _network_bandwidth_remaining, network_bandwidth_limit_exceeded, "network bandwidth limit exceeded" );
-   KOINOS_ASSERT( bytes >= 0, reversion_exception, "cannot consume negative network bandwidth" );
+   KOINOS_ASSERT( bytes >= 0, network_bandwidth_limit_exceeded, "cannot consume negative network bandwidth" );
 
    if ( auto session = _session.lock() )
    {
@@ -107,7 +107,7 @@ uint64_t resource_meter::network_bandwidth_remaining()
 void resource_meter::use_compute_bandwidth( int64_t ticks )
 {
    KOINOS_ASSERT( ticks <= _compute_bandwidth_remaining, compute_bandwidth_limit_exceeded, "compute bandwidth limit exceeded" );
-   KOINOS_ASSERT( ticks >= 0, compute_bandwidth_limit_exceeded, "cannot consume negative network bandwidth" );
+   KOINOS_ASSERT( ticks >= 0, compute_bandwidth_limit_exceeded, "cannot consume compute bandwidth bandwidth" );
 
    if ( auto session = _session.lock() )
    {

--- a/libraries/chain/resource_meter.cpp
+++ b/libraries/chain/resource_meter.cpp
@@ -4,7 +4,7 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-using uint128_t = boost::multiprecision::uint128_t;
+using int128_t = boost::multiprecision::int128_t;
 
 namespace koinos::chain {
 
@@ -33,18 +33,21 @@ void resource_meter::set_resource_limit_data( const resource_limit_data& rld )
    _compute_bandwidth_remaining = _resource_limit_data.compute_bandwidth_limit();
 }
 
-void resource_meter::use_disk_storage( uint64_t bytes )
+void resource_meter::use_disk_storage( int64_t bytes )
 {
-   KOINOS_ASSERT( bytes <= _disk_storage_remaining, disk_storage_limit_exceeded, "disk storage limit exceeded" );
+   KOINOS_ASSERT( bytes <= int64_t( _disk_storage_remaining ), disk_storage_limit_exceeded, "disk storage limit exceeded" );
 
    if ( auto session = _session.lock() )
    {
-      uint128_t rc_cost = uint128_t( bytes ) * _resource_limit_data.disk_storage_cost();
-      KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
-      session->use_rc( rc_cost.convert_to< uint64_t >() );
+      int128_t rc_cost = int128_t( bytes ) * _resource_limit_data.disk_storage_cost();
+      KOINOS_ASSERT( rc_cost <= std::numeric_limits< int64_t >::max(), reversion_exception, "rc overflow" );
+      session->use_rc( rc_cost.convert_to< int64_t >() );
    }
 
-   _disk_storage_remaining -= bytes;
+   if ( bytes >= 0 )
+      _disk_storage_remaining -= uint64_t( bytes );
+   else
+      _disk_storage_remaining += uint64_t( -1 * bytes );
 }
 
 uint64_t resource_meter::disk_storage_used()
@@ -59,26 +62,25 @@ uint64_t resource_meter::disk_storage_remaining()
       auto cost = _resource_limit_data.disk_storage_cost();
 
       if ( cost > 0 )
-         return session->remaining_rc() / cost;
-      else
-         return std::numeric_limits< uint64_t >::max();
+         return std::min( session->remaining_rc() / cost, _disk_storage_remaining );
    }
 
    return _disk_storage_remaining;
 }
 
-void resource_meter::use_network_bandwidth( uint64_t bytes )
+void resource_meter::use_network_bandwidth( int64_t bytes )
 {
    KOINOS_ASSERT( bytes <= _network_bandwidth_remaining, network_bandwidth_limit_exceeded, "network bandwidth limit exceeded" );
+   KOINOS_ASSERT( bytes >= 0, reversion_exception, "cannot consume negative network bandwidth" );
 
    if ( auto session = _session.lock() )
    {
-      uint128_t rc_cost = uint128_t( bytes ) * _resource_limit_data.network_bandwidth_cost();
-      KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
-      session->use_rc( rc_cost.convert_to< uint64_t >() );
+      int128_t rc_cost = int128_t( bytes ) * _resource_limit_data.network_bandwidth_cost();
+      KOINOS_ASSERT( rc_cost <= std::numeric_limits< int64_t >::max(), reversion_exception, "rc overflow" );
+      session->use_rc( rc_cost.convert_to< int64_t >() );
    }
 
-   _network_bandwidth_remaining -= bytes;
+   _network_bandwidth_remaining -= uint64_t( bytes );
 }
 
 uint64_t resource_meter::network_bandwidth_used()
@@ -93,26 +95,25 @@ uint64_t resource_meter::network_bandwidth_remaining()
       auto cost = _resource_limit_data.network_bandwidth_cost();
 
       if ( cost > 0 )
-         return session->remaining_rc() / cost;
-      else
-         return std::numeric_limits< uint64_t >::max();
+         return std::min( session->remaining_rc() / cost, _network_bandwidth_remaining );
    }
 
    return _network_bandwidth_remaining;
 }
 
-void resource_meter::use_compute_bandwidth( uint64_t ticks )
+void resource_meter::use_compute_bandwidth( int64_t ticks )
 {
    KOINOS_ASSERT( ticks <= _compute_bandwidth_remaining, compute_bandwidth_limit_exceeded, "compute bandwidth limit exceeded" );
+   KOINOS_ASSERT( ticks >= 0, compute_bandwidth_limit_exceeded, "cannot consume negative network bandwidth" );
 
    if ( auto session = _session.lock() )
    {
-      uint128_t rc_cost = uint128_t( ticks ) * _resource_limit_data.compute_bandwidth_cost();
-      KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
-      session->use_rc( rc_cost.convert_to< uint64_t >() );
+      int128_t rc_cost = int128_t( ticks ) * _resource_limit_data.compute_bandwidth_cost();
+      KOINOS_ASSERT( rc_cost <= std::numeric_limits< int64_t >::max(), reversion_exception, "rc overflow" );
+      session->use_rc( rc_cost.convert_to< int64_t >() );
    }
 
-   _compute_bandwidth_remaining -= ticks;
+   _compute_bandwidth_remaining -= uint64_t( ticks );
 }
 
 uint64_t resource_meter::compute_bandwidth_used()
@@ -127,9 +128,7 @@ uint64_t resource_meter::compute_bandwidth_remaining()
       auto cost = _resource_limit_data.compute_bandwidth_cost();
 
       if ( cost > 0 )
-         return session->remaining_rc() / cost;
-      else
-         return std::numeric_limits< uint64_t >::max();
+         return std::min( session->remaining_rc() / cost, _compute_bandwidth_remaining );
    }
 
    return _compute_bandwidth_remaining;

--- a/libraries/chain/session.cpp
+++ b/libraries/chain/session.cpp
@@ -3,10 +3,10 @@
 
 namespace koinos::chain {
 
-session::session( uint64_t begin_rc ) : _begin_rc( begin_rc ), _end_rc( begin_rc ) {}
+session::session( int64_t begin_rc ) : _begin_rc( begin_rc ), _end_rc( begin_rc ) {}
 session::~session() = default;
 
-void session::use_rc( uint64_t rc )
+void session::use_rc( int64_t rc )
 {
    KOINOS_ASSERT( rc <= _end_rc, insufficient_rc_exception, "insufficent rc" );
    _end_rc -= rc;
@@ -14,12 +14,15 @@ void session::use_rc( uint64_t rc )
 
 uint64_t session::remaining_rc()
 {
-   return _end_rc;
+   return uint64_t( std::min( _begin_rc, _end_rc ) );
 }
 
 uint64_t session::used_rc()
 {
-   return _begin_rc - _end_rc;
+   if ( _end_rc > _begin_rc )
+      return 0;
+
+   return uint64_t( _begin_rc - _end_rc );
 }
 
 void session::push_event( const protocol::event_data& ev )

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -937,9 +937,9 @@ THUNK_DEFINE( void, put_object, ((const object_space&) space, (const std::string
    auto val = util::converter::as< state_db::object_value >( obj );
 
    auto bytes_used = state->put_object( space, key, &val );
+   bytes_used += util::converter::as< std::string >( space ).size() + util::converter::as< std::string >( key ).size();
 
-   if ( bytes_used > 0 )
-      context.resource_meter().use_disk_storage( bytes_used );
+   context.resource_meter().use_disk_storage( bytes_used );
 }
 
 THUNK_DEFINE( void, remove_object, ((const object_space&) space, (const std::string&) key) )

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -936,10 +936,7 @@ THUNK_DEFINE( void, put_object, ((const object_space&) space, (const std::string
    KOINOS_ASSERT( state, internal_error_exception, "current state node does not exist" );
    auto val = util::converter::as< state_db::object_value >( obj );
 
-   auto bytes_used = state->put_object( space, key, &val );
-   bytes_used += util::converter::as< std::string >( space ).size() + util::converter::as< std::string >( key ).size();
-
-   context.resource_meter().use_disk_storage( bytes_used );
+   context.resource_meter().use_disk_storage( state->put_object( space, key, &val ) );
 }
 
 THUNK_DEFINE( void, remove_object, ((const object_space&) space, (const std::string&) key) )
@@ -951,10 +948,7 @@ THUNK_DEFINE( void, remove_object, ((const object_space&) space, (const std::str
    auto state = context.get_state_node();
    KOINOS_ASSERT( state, internal_error_exception, "current state node does not exist" );
 
-   auto bytes_used = state->remove_object( space, key );
-   bytes_used -= util::converter::as< std::string >( space ).size() + util::converter::as< std::string >( key ).size();
-
-   context.resource_meter().use_disk_storage( bytes_used );
+   context.resource_meter().use_disk_storage( state->remove_object( space, key ) );
 }
 
 THUNK_DEFINE( get_object_result, get_object, ((const object_space&) space, (const std::string&) key) )

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -951,7 +951,10 @@ THUNK_DEFINE( void, remove_object, ((const object_space&) space, (const std::str
    auto state = context.get_state_node();
    KOINOS_ASSERT( state, internal_error_exception, "current state node does not exist" );
 
-   state->remove_object( space, key );
+   auto bytes_used = state->remove_object( space, key );
+   bytes_used -= util::converter::as< std::string >( space ).size() + util::converter::as< std::string >( key ).size();
+
+   context.resource_meter().use_disk_storage( bytes_used );
 }
 
 THUNK_DEFINE( get_object_result, get_object, ((const object_space&) space, (const std::string&) key) )

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -71,12 +71,12 @@ class abstract_state_node
        * - Fail if node is not writable.
        * - If object exists, object is overwritten.
        */
-      int32_t put_object( const object_space& space, const object_key& key, const object_value* val );
+      int64_t put_object( const object_space& space, const object_key& key, const object_value* val );
 
       /**
        * Remove an object from the state_node
        */
-      int32_t remove_object( const object_space& space, const object_key& key );
+      int64_t remove_object( const object_space& space, const object_key& key );
 
       /**
        * Return true if the node is writable.

--- a/libraries/state_db/include/koinos/state_db/state_db.hpp
+++ b/libraries/state_db/include/koinos/state_db/state_db.hpp
@@ -76,7 +76,7 @@ class abstract_state_node
       /**
        * Remove an object from the state_node
        */
-      void remove_object( const object_space& space, const object_key& key );
+      int32_t remove_object( const object_space& space, const object_key& key );
 
       /**
        * Return true if the node is writable.

--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -82,8 +82,8 @@ class state_node_impl final
       const object_value* get_object( const object_space& space, const object_key& key ) const;
       std::pair< const object_value*, const object_key > get_next_object( const object_space& space, const object_key& key ) const;
       std::pair< const object_value*, const object_key > get_prev_object( const object_space& space, const object_key& key ) const;
-      int32_t put_object( const object_space& space, const object_key& key, const object_value* val );
-      int32_t remove_object( const object_space& space, const object_key& key );
+      int64_t put_object( const object_space& space, const object_key& key, const object_value* val );
+      int64_t remove_object( const object_space& space, const object_key& key );
       crypto::multihash get_merkle_root() const;
 
       state_delta_ptr   _state;
@@ -493,7 +493,7 @@ std::pair< const object_value*, const object_key > state_node_impl::get_prev_obj
    return { nullptr, null_key };
 }
 
-int32_t state_node_impl::put_object( const object_space& space, const object_key& key, const object_value* val )
+int64_t state_node_impl::put_object( const object_space& space, const object_key& key, const object_value* val )
 {
    KOINOS_ASSERT( _state->is_writable(), node_finalized, "cannot write to a finalized node" );
 
@@ -502,7 +502,7 @@ int32_t state_node_impl::put_object( const object_space& space, const object_key
    db_key.set_key( key );
    auto key_string = util::converter::as< std::string >( db_key );
 
-   int32_t bytes_used = 0;
+   int64_t bytes_used = 0;
    auto pobj = merge_state( _state ).find( key_string );
 
    if ( pobj != nullptr )
@@ -516,7 +516,7 @@ int32_t state_node_impl::put_object( const object_space& space, const object_key
    return bytes_used;
 }
 
-int32_t state_node_impl::remove_object( const object_space& space, const object_key& key )
+int64_t state_node_impl::remove_object( const object_space& space, const object_key& key )
 {
    KOINOS_ASSERT( _state->is_writable(), node_finalized, "cannot write to a finalized node" );
 
@@ -525,7 +525,7 @@ int32_t state_node_impl::remove_object( const object_space& space, const object_
    db_key.set_key( key );
    auto key_string = util::converter::as< std::string >( db_key );
 
-   int32_t bytes_used = 0;
+   int64_t bytes_used = 0;
    auto pobj = merge_state( _state ).find( key_string );
 
    if ( pobj != nullptr )
@@ -564,12 +564,12 @@ std::pair< const object_value*, const object_key > abstract_state_node::get_prev
    return impl->get_prev_object( space, key );
 }
 
-int32_t abstract_state_node::put_object( const object_space& space, const object_key& key, const object_value* val )
+int64_t abstract_state_node::put_object( const object_space& space, const object_key& key, const object_value* val )
 {
    return impl->put_object( space, key, val );
 }
 
-int32_t abstract_state_node::remove_object( const object_space& space, const object_key& key )
+int64_t abstract_state_node::remove_object( const object_space& space, const object_key& key )
 {
    return impl->remove_object( space, key );
 }

--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -507,6 +507,8 @@ int32_t state_node_impl::put_object( const object_space& space, const object_key
 
    if ( pobj != nullptr )
       bytes_used -= pobj->size();
+   else
+      bytes_used += key_string.size();
 
    bytes_used += val->size();
    _state->put( key_string, *val );
@@ -527,7 +529,10 @@ int32_t state_node_impl::remove_object( const object_space& space, const object_
    auto pobj = merge_state( _state ).find( key_string );
 
    if ( pobj != nullptr )
+   {
       bytes_used -= pobj->size();
+      bytes_used -= key_string.size();
+   }
 
    _state->erase( key_string );
 

--- a/tests/tests/stack_test.cpp
+++ b/tests/tests/stack_test.cpp
@@ -170,10 +170,12 @@ struct stack_fixture
          for ( const auto& entry : _genesis_data.entries() )
          {
             KOINOS_ASSERT(
-               root->put_object( entry.space(), entry.key(), &entry.value() ) == entry.value().size(),
+               !root->get_object( entry.space(), entry.key() ),
                koinos::chain::unexpected_state,
                "encountered unexpected object in initial state"
             );
+
+            root->put_object( entry.space(), entry.key(), &entry.value() );
          }
          LOG(info) << "Wrote " << _genesis_data.entries().size() << " genesis objects into new database";
 
@@ -189,10 +191,11 @@ struct stack_fixture
          LOG(info) << "Calculated chain ID: " << chain_id;
          auto chain_id_str = util::converter::as< std::string >( chain_id );
          KOINOS_ASSERT(
-            root->put_object( chain::state::space::metadata(), chain::state::key::chain_id, &chain_id_str ) == chain_id_str.size(),
+            !root->get_object( chain::state::space::metadata(), chain::state::key::chain_id ),
             koinos::chain::unexpected_state,
             "encountered unexpected chain id in initial state"
          );
+         root->put_object( chain::state::space::metadata(), chain::state::key::chain_id, &chain_id_str );
          LOG(info) << "Wrote chain ID into new database";
       } );
 

--- a/tests/tests/state_db_test.cpp
+++ b/tests/tests/state_db_test.cpp
@@ -70,10 +70,15 @@ BOOST_AUTO_TEST_CASE( basic_test )
    std::string a_key = "a";
    std::string a_val = "alice";
 
+   chain::database_key db_key;
+   *db_key.mutable_space() = space;
+   db_key.set_key( a_key );
+   auto key_size = util::converter::as< std::string >( db_key ).size();
+
    crypto::multihash state_id = crypto::hash( crypto::multicodec::sha2_256, 1 );
    auto state_1 = db.create_writable_node( db.get_head()->id(), state_id );
    BOOST_REQUIRE( state_1 );
-   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() );
+   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() + key_size );
 
    // Object should not exist on older state node
    BOOST_CHECK_EQUAL( db.get_root()->get_object( space, a_key ), nullptr );
@@ -536,7 +541,12 @@ BOOST_AUTO_TEST_CASE( reset_test )
    std::string a_key = "a";
    std::string a_val = "alice";
 
-   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() );
+   chain::database_key db_key;
+   *db_key.mutable_space() = space;
+   db_key.set_key( a_key );
+   auto key_size = util::converter::as< std::string >( db_key ).size();
+
+   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() + key_size );
    db.finalize_node( state_1->id() );
 
    auto val_ptr = db.get_head()->get_object( space, a_key );
@@ -569,7 +579,7 @@ BOOST_AUTO_TEST_CASE( reset_test )
    BOOST_TEST_MESSAGE( "Creating object on committed state node" );
 
    state_1 = db.create_writable_node( db.get_head()->id(), state_id );
-   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() );
+   BOOST_CHECK_EQUAL( state_1->put_object( space, a_key, &a_val ), a_val.size() + key_size );
    db.finalize_node( state_1->id() );
    auto state_1_id = state_1->id();
    state_1.reset();
@@ -611,7 +621,12 @@ BOOST_AUTO_TEST_CASE( anonymous_node_test )
    std::string a_key = "a";
    std::string a_val = "alice";
 
-   BOOST_CHECK( state_1->put_object( space, a_key, &a_val ) == a_val.size() );
+   chain::database_key db_key;
+   *db_key.mutable_space() = space;
+   db_key.set_key( a_key );
+   auto key_size = util::converter::as< std::string >( db_key ).size();
+
+   BOOST_CHECK( state_1->put_object( space, a_key, &a_val ) == a_val.size() + key_size );
 
    auto ptr = state_1->get_object( space, a_key );
    BOOST_REQUIRE( ptr );


### PR DESCRIPTION
Resolves koinos/koinos-internal#120

## Brief description

State DB accounts for key size when returning bytes consumed.
The resource meter can now consume negative disk storage (freeing storage), refunding rc to the user. This cannot cause the resource meter or the payer session to set rc or disk storage above the original value.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

