### PR TITLE
System resource meter

### DIFF
--- a/libraries/chain/host_api.cpp
+++ b/libraries/chain/host_api.cpp
@@ -60,7 +60,7 @@ int32_t host_api::invoke_system_call( uint32_t sid, char* ret_ptr, uint32_t ret_
    );
 
    if ( _ctx.get_privilege() == privilege::user_mode && retcode >= reversion )
-      KOINOS_THROW( reversion_exception, "" );
+      throw reversion_exception( retcode, "" );
 
    if ( sid == system_call_id::exit )
    {

--- a/libraries/chain/include/koinos/chain/resource_meter.hpp
+++ b/libraries/chain/include/koinos/chain/resource_meter.hpp
@@ -30,22 +30,28 @@ public:
    void set_session( std::shared_ptr< abstract_rc_session > s );
 
    void use_disk_storage( uint64_t bytes );
-   uint64_t disk_storage_used();
-   uint64_t disk_storage_remaining();
+   uint64_t disk_storage_used() const;
+   uint64_t disk_storage_remaining() const;
+   uint64_t system_disk_storage_used() const;
 
    void use_network_bandwidth( uint64_t bytes );
-   uint64_t network_bandwidth_used();
-   uint64_t network_bandwidth_remaining();
+   uint64_t network_bandwidth_used() const;
+   uint64_t network_bandwidth_remaining() const;
+   uint64_t system_network_bandwidth_used() const;
 
    void use_compute_bandwidth( uint64_t ticks );
-   uint64_t compute_bandwidth_used();
-   uint64_t compute_bandwidth_remaining();
+   uint64_t compute_bandwidth_used() const;
+   uint64_t compute_bandwidth_remaining() const;
+   uint64_t system_compute_bandwidth_used() const;
 
 private:
 
-   uint64_t _disk_storage_remaining      = 0;
-   uint64_t _network_bandwidth_remaining = 0;
-   uint64_t _compute_bandwidth_remaining = 0;
+   uint64_t _disk_storage_remaining        = 0;
+   uint64_t _system_disk_storage_used      = 0;
+   uint64_t _network_bandwidth_remaining   = 0;
+   uint64_t _system_network_bandwidth_used = 0;
+   uint64_t _compute_bandwidth_remaining   = 0;
+   uint64_t _system_compute_bandwidth_used = 0;
    resource_limit_data _resource_limit_data;
    std::weak_ptr< abstract_rc_session > _session;
 };

--- a/libraries/chain/include/koinos/chain/thunk_dispatcher.hpp
+++ b/libraries/chain/include/koinos/chain/thunk_dispatcher.hpp
@@ -270,13 +270,9 @@ namespace detail
       {
          std::apply( thunk, thunk_args );
       }
-      catch ( const reversion_exception& )
+      catch ( const koinos::exception& e )
       {
-         code = reversion;
-      }
-      catch ( const failure_exception& )
-      {
-         code = failure;
+         code = e.get_code();
       }
 
       return code;

--- a/libraries/chain/resource_meter.cpp
+++ b/libraries/chain/resource_meter.cpp
@@ -27,10 +27,13 @@ resource_meter::~resource_meter() = default;
 
 void resource_meter::set_resource_limit_data( const resource_limit_data& rld )
 {
-   _resource_limit_data         = rld;
-   _disk_storage_remaining      = _resource_limit_data.disk_storage_limit();
-   _network_bandwidth_remaining = _resource_limit_data.network_bandwidth_limit();
-   _compute_bandwidth_remaining = _resource_limit_data.compute_bandwidth_limit();
+   _resource_limit_data           = rld;
+   _disk_storage_remaining        = _resource_limit_data.disk_storage_limit();
+   _system_disk_storage_used      = 0;
+   _network_bandwidth_remaining   = _resource_limit_data.network_bandwidth_limit();
+   _system_network_bandwidth_used = 0;
+   _compute_bandwidth_remaining   = _resource_limit_data.compute_bandwidth_limit();
+   _system_compute_bandwidth_used = 0;
 }
 
 void resource_meter::use_disk_storage( uint64_t bytes )
@@ -43,16 +46,20 @@ void resource_meter::use_disk_storage( uint64_t bytes )
       KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
       session->use_rc( rc_cost.convert_to< uint64_t >() );
    }
+   else
+   {
+      _system_disk_storage_used += bytes;
+   }
 
    _disk_storage_remaining -= bytes;
 }
 
-uint64_t resource_meter::disk_storage_used()
+uint64_t resource_meter::disk_storage_used() const
 {
    return _resource_limit_data.disk_storage_limit() - _disk_storage_remaining;
 }
 
-uint64_t resource_meter::disk_storage_remaining()
+uint64_t resource_meter::disk_storage_remaining() const
 {
    if ( auto session = _session.lock() )
    {
@@ -67,6 +74,11 @@ uint64_t resource_meter::disk_storage_remaining()
    return _disk_storage_remaining;
 }
 
+uint64_t resource_meter::system_disk_storage_used() const
+{
+   return _system_disk_storage_used;
+}
+
 void resource_meter::use_network_bandwidth( uint64_t bytes )
 {
    KOINOS_ASSERT( bytes <= _network_bandwidth_remaining, network_bandwidth_limit_exceeded, "network bandwidth limit exceeded" );
@@ -77,16 +89,20 @@ void resource_meter::use_network_bandwidth( uint64_t bytes )
       KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
       session->use_rc( rc_cost.convert_to< uint64_t >() );
    }
+   else
+   {
+      _system_network_bandwidth_used += bytes;
+   }
 
    _network_bandwidth_remaining -= bytes;
 }
 
-uint64_t resource_meter::network_bandwidth_used()
+uint64_t resource_meter::network_bandwidth_used() const
 {
    return _resource_limit_data.network_bandwidth_limit() - _network_bandwidth_remaining;
 }
 
-uint64_t resource_meter::network_bandwidth_remaining()
+uint64_t resource_meter::network_bandwidth_remaining() const
 {
    if ( auto session = _session.lock() )
    {
@@ -101,6 +117,11 @@ uint64_t resource_meter::network_bandwidth_remaining()
    return _network_bandwidth_remaining;
 }
 
+uint64_t resource_meter::system_network_bandwidth_used() const
+{
+   return _system_network_bandwidth_used;
+}
+
 void resource_meter::use_compute_bandwidth( uint64_t ticks )
 {
    KOINOS_ASSERT( ticks <= _compute_bandwidth_remaining, compute_bandwidth_limit_exceeded, "compute bandwidth limit exceeded" );
@@ -111,16 +132,20 @@ void resource_meter::use_compute_bandwidth( uint64_t ticks )
       KOINOS_ASSERT( rc_cost <= std::numeric_limits< uint64_t >::max(), reversion_exception, "rc overflow" );
       session->use_rc( rc_cost.convert_to< uint64_t >() );
    }
+   else
+   {
+      _system_compute_bandwidth_used += ticks;
+   }
 
    _compute_bandwidth_remaining -= ticks;
 }
 
-uint64_t resource_meter::compute_bandwidth_used()
+uint64_t resource_meter::compute_bandwidth_used() const
 {
    return _resource_limit_data.compute_bandwidth_limit() - _compute_bandwidth_remaining;
 }
 
-uint64_t resource_meter::compute_bandwidth_remaining()
+uint64_t resource_meter::compute_bandwidth_remaining() const
 {
    if ( auto session = _session.lock() )
    {
@@ -133,6 +158,11 @@ uint64_t resource_meter::compute_bandwidth_remaining()
    }
 
    return _compute_bandwidth_remaining;
+}
+
+uint64_t resource_meter::system_compute_bandwidth_used() const
+{
+   return _system_compute_bandwidth_used;
 }
 
 void resource_meter::set_session( std::shared_ptr< abstract_rc_session > s )

--- a/tests/tests/controller_test.cpp
+++ b/tests/tests/controller_test.cpp
@@ -586,8 +586,15 @@ BOOST_AUTO_TEST_CASE( read_contract_tests )
    BOOST_TEST_MESSAGE( "Test read contract db write" );
 
    request.set_contract_id( util::converter::as< std::string >( key3.get_public_key().to_address_bytes() ) );
-   BOOST_REQUIRE_THROW( _controller.read_contract( request ), koinos::chain::read_only_context_exception );
-
+   try
+   {
+      _controller.read_contract( request );
+      BOOST_FAIL( "expected reversion_exception not thrown" );
+   }
+   catch ( const chain::reversion_exception& e )
+   {
+      BOOST_REQUIRE_EQUAL( e.get_code(), chain::read_only_context );
+   }
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
 BOOST_AUTO_TEST_CASE( transaction_reversion_test )

--- a/tests/tests/thunk_test.cpp
+++ b/tests/tests/thunk_test.cpp
@@ -1457,6 +1457,113 @@ BOOST_AUTO_TEST_CASE( get_chain_id )
    BOOST_REQUIRE_EQUAL( chain_id_str, chain::system_call::get_chain_id( ctx ) );
 }
 
+BOOST_AUTO_TEST_CASE( system_resources )
+{ try {
+   auto resource_limits = chain::system_call::get_resource_limits( ctx );
+   auto& meter = ctx.resource_meter();
+
+   BOOST_TEST_MESSAGE( "Set and check initial resource meter" );
+
+   meter.set_resource_limit_data( resource_limits );
+
+   uint64_t disk_storage_used = 0;
+   uint64_t system_disk_storage_used = 0;
+   uint64_t network_bandwidth_used = 0;
+   uint64_t system_network_bandwidth_used = 0;
+   uint64_t compute_bandwidth_used = 0;
+   uint64_t system_compute_bandwidth_used = 0;
+
+   BOOST_CHECK_EQUAL( meter.disk_storage_remaining(), resource_limits.disk_storage_limit() - disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.disk_storage_used(), disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.system_disk_storage_used(), system_disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_remaining(), resource_limits.network_bandwidth_limit() - network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_used(), network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_network_bandwidth_used(), system_network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_remaining(), resource_limits.compute_bandwidth_limit() - compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_used(), compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_compute_bandwidth_used(), system_compute_bandwidth_used );
+
+   BOOST_TEST_MESSAGE( "Use system resources" );
+
+   meter.use_disk_storage( 100 );
+   disk_storage_used += 100;
+   system_disk_storage_used += 100;
+
+   BOOST_CHECK_EQUAL( meter.disk_storage_remaining(), resource_limits.disk_storage_limit() - disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.disk_storage_used(), disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.system_disk_storage_used(), system_disk_storage_used );
+
+   meter.use_network_bandwidth( 200 );
+   network_bandwidth_used += 200;
+   system_network_bandwidth_used += 200;
+
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_remaining(), resource_limits.network_bandwidth_limit() - network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_used(), network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_network_bandwidth_used(), system_network_bandwidth_used );
+
+   meter.use_compute_bandwidth( 300 );
+   compute_bandwidth_used += 300;
+   system_compute_bandwidth_used += 300;
+
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_remaining(), resource_limits.compute_bandwidth_limit() - compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_used(), compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_compute_bandwidth_used(), system_compute_bandwidth_used );
+
+   BOOST_TEST_MESSAGE( "Use session resources" );
+
+   auto session = ctx.make_session( 10'000'000 );
+
+   meter.use_disk_storage( 400 );
+   disk_storage_used += 400;
+
+   BOOST_CHECK_EQUAL( meter.disk_storage_remaining(), resource_limits.disk_storage_limit() - disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.disk_storage_used(), disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.system_disk_storage_used(), system_disk_storage_used );
+
+   meter.use_network_bandwidth( 500 );
+   network_bandwidth_used += 500;
+
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_remaining(), resource_limits.network_bandwidth_limit() - network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_used(), network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_network_bandwidth_used(), system_network_bandwidth_used );
+
+   meter.use_compute_bandwidth( 600 );
+   compute_bandwidth_used += 600;
+
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_remaining(), resource_limits.compute_bandwidth_limit() - compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_used(), compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_compute_bandwidth_used(), system_compute_bandwidth_used );
+
+   BOOST_TEST_MESSAGE( "End session and resume using system resources" );
+
+   session.reset();
+
+   meter.use_disk_storage( 700 );
+   disk_storage_used += 700;
+   system_disk_storage_used += 700;
+
+   BOOST_CHECK_EQUAL( meter.disk_storage_remaining(), resource_limits.disk_storage_limit() - disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.disk_storage_used(), disk_storage_used );
+   BOOST_CHECK_EQUAL( meter.system_disk_storage_used(), system_disk_storage_used );
+
+   meter.use_network_bandwidth( 800 );
+   network_bandwidth_used += 800;
+   system_network_bandwidth_used += 800;
+
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_remaining(), resource_limits.network_bandwidth_limit() - network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.network_bandwidth_used(), network_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_network_bandwidth_used(), system_network_bandwidth_used );
+
+   meter.use_compute_bandwidth( 900 );
+   compute_bandwidth_used += 900;
+   system_compute_bandwidth_used += 900;
+
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_remaining(), resource_limits.compute_bandwidth_limit() - compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.compute_bandwidth_used(), compute_bandwidth_used );
+   BOOST_CHECK_EQUAL( meter.system_compute_bandwidth_used(), system_compute_bandwidth_used );
+
+} KOINOS_CATCH_LOG_AND_RETHROW(info) }
+
 BOOST_AUTO_TEST_CASE( thunk_time )
 { try {
    crypto::multihash contract_seed = crypto::hash( crypto::multicodec::sha2_256, std::string{ "contract" } );


### PR DESCRIPTION
Resolves #684

## Brief description

Tracks resources used by the system separately from resources used by transactions (sessions).

Note: the tests currently fail due to a bug fixed in #681

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

