### PR TITLE
Exception error_data

### DIFF
--- a/libraries/chain/host_api.cpp
+++ b/libraries/chain/host_api.cpp
@@ -30,15 +30,15 @@ int32_t host_api::invoke_thunk( uint32_t tid, char* ret_ptr, uint32_t ret_len, c
    catch ( koinos::exception& e )
    {
       code = e.get_code();
-      error.set_message( e.get_message() );
+      error = e.get_data();
    }
 
    if ( tid == system_call_id::exit )
    {
       if ( code >= chain::reversion )
-         throw reversion_exception( code, error.message() );
+         throw reversion_exception( code, error );
       if ( code <= chain::failure )
-         throw failure_exception( code, error.message() );
+         throw failure_exception( code, error );
 
       throw success_exception( code );
    }
@@ -115,21 +115,21 @@ int32_t host_api::invoke_system_call( uint32_t sid, char* ret_ptr, uint32_t ret_
    }
    catch ( const koinos::exception& e )
    {
-      error.set_message( e.get_message() );
+      error = e.get_data();
       code = e.get_code();
    }
 
    if ( _ctx.get_privilege() == privilege::user_mode && code >= reversion )
-      throw reversion_exception( code, error.message() );
+      throw reversion_exception( code, error );
 
    if ( sid == system_call_id::exit )
    {
       if ( code >= reversion )
-         throw reversion_exception( code, error.message() );
+         throw reversion_exception( code, error );
       if ( code <= failure )
-         throw failure_exception( code, error.message() );
+         throw failure_exception( code, error );
 
-      throw success_exception( error.message() );
+      throw success_exception();
    }
 
    if ( code != chain::success )

--- a/libraries/chain/include/koinos/chain/thunk_utils.hpp
+++ b/libraries/chain/include/koinos/chain/thunk_utils.hpp
@@ -268,9 +268,9 @@ namespace koinos::chain::detail {
                if ( _res.code )                                                                                            \
                {                                                                                                           \
                   if ( _res.code >= chain::reversion )                                                                     \
-                     throw chain::reversion_exception( _res.code, _res.res.error().message() );                            \
+                     throw chain::reversion_exception( _res.code, _res.res.error() );                                      \
                   else if ( _res.code <= chain::failure )                                                                  \
-                     throw chain::failure_exception( _res.code, _res.res.error().message() );                              \
+                     throw chain::failure_exception( _res.code, _res.res.error() );                                        \
                }                                                                                                           \
                else if ( _sid == system_call_id::exit )                                                                    \
                   throw chain::success_exception( _res.code );                                                             \

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -1213,9 +1213,9 @@ THUNK_DEFINE( call_result, call, ((const std::string&) contract_id, (uint32_t) e
       const auto& error = res.res.error();
 
       if ( res.code >= reversion )
-         throw reversion_exception( res.code, error.message() );
+         throw reversion_exception( res.code, error );
       if ( res.code <= failure )
-         throw failure_exception( res.code, error.message() );
+         throw failure_exception( res.code, error );
    }
 
    call_result ret;
@@ -1238,14 +1238,14 @@ THUNK_DEFINE( void, exit, ((int32_t) code, (result) res) )
    if ( code >= reversion )
    {
       if ( validate_utf( error.message() ) )
-         throw reversion_exception( code, error.message() );
+         throw reversion_exception( code, error );
       else
          throw reversion_exception( chain::reversion, "error message contains invalid utf-8" );
    }
    else // code <= failure
    {
       if ( validate_utf( error.message() ) )
-         throw failure_exception( code, error.message() );
+         throw failure_exception( code, error );
       else
          throw reversion_exception( chain::reversion, "error message contains invalid utf-8" );
    }


### PR DESCRIPTION
Resolves #701

## Brief description

Store/load error_data on `koinos::exception`

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
# ctest -j8
Test project /Users/mdv/git/koinos-chain/build/tests
      Start 48: koinos_tests-thunk_tests/thunk_time
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start 42: koinos_tests-thunk_tests/authorize_tests
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start 38: koinos_tests-thunk_tests/token_tests
      Start 15: koinos_tests-state_db_tests/fork_tests
      Start  6: koinos_tests-controller_tests/receipt_test
 1/48 Test #15: koinos_tests-state_db_tests/fork_tests ............................   Passed    1.08 sec
      Start 45: koinos_tests-thunk_tests/system_rc
 2/48 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    1.09 sec
      Start 46: koinos_tests-thunk_tests/contract_exit
 3/48 Test #38: koinos_tests-thunk_tests/token_tests ..............................   Passed    1.24 sec
      Start 10: koinos_tests-stack_tests/user_from_user
 4/48 Test #46: koinos_tests-thunk_tests/contract_exit ............................   Passed    0.19 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 5/48 Test #45: koinos_tests-thunk_tests/system_rc ................................   Passed    0.28 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
 6/48 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    1.42 sec
      Start  9: koinos_tests-stack_tests/syscall_from_user
 7/48 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.21 sec
      Start  4: koinos_tests-controller_tests/read_contract_tests
 8/48 Test #42: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    1.47 sec
      Start  7: koinos_tests-controller_tests/system_call_override_test
 9/48 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.24 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
10/48 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    1.57 sec
      Start 39: koinos_tests-thunk_tests/tick_limit
11/48 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.25 sec
      Start 27: koinos_tests-thunk_tests/override_tests
12/48 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.21 sec
      Start  8: koinos_tests-stack_tests/simple_user_contract
13/48 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.21 sec
      Start 17: koinos_tests-state_db_tests/reset_test
14/48 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.29 sec
      Start 16: koinos_tests-state_db_tests/merge_iterator
15/48 Test #39: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.23 sec
      Start 26: koinos_tests-thunk_tests/contract_tests
16/48 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.27 sec
      Start 47: koinos_tests-thunk_tests/syscall_override_return
17/48 Test #27: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.20 sec
      Start  1: koinos_tests-controller_tests/submission_tests
18/48 Test #16: koinos_tests-state_db_tests/merge_iterator ........................   Passed    0.19 sec
      Start 24: koinos_tests-thunk_tests/get_block_field
19/48 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.24 sec
      Start 40: koinos_tests-thunk_tests/disk_usage
20/48 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.10 sec
      Start 20: koinos_tests-state_db_tests/rocksdb_backend_test
21/48 Test #17: koinos_tests-state_db_tests/reset_test ............................   Passed    0.26 sec
      Start 23: koinos_tests-thunk_tests/get_transaction_field
22/48 Test #24: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.09 sec
      Start 36: koinos_tests-thunk_tests/transaction_nonce_test
23/48 Test #40: koinos_tests-thunk_tests/disk_usage ...............................   Passed    0.09 sec
      Start 43: koinos_tests-thunk_tests/get_chain_id
24/48 Test #20: koinos_tests-state_db_tests/rocksdb_backend_test ..................   Passed    0.10 sec
      Start 33: koinos_tests-thunk_tests/last_irreversible_block_test
25/48 Test #26: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.23 sec
      Start 28: koinos_tests-thunk_tests/thunk_test
26/48 Test #43: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.08 sec
      Start 41: koinos_tests-thunk_tests/transaction_reversion
27/48 Test #36: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.09 sec
      Start 25: koinos_tests-thunk_tests/db_crud
28/48 Test #28: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.08 sec
      Start 31: koinos_tests-thunk_tests/hash_thunk_test
29/48 Test #33: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.10 sec
      Start 30: koinos_tests-thunk_tests/get_head_info_thunk_test
30/48 Test #47: koinos_tests-thunk_tests/syscall_override_return ..................   Passed    0.37 sec
      Start 32: koinos_tests-thunk_tests/privileged_calls
31/48 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    2.19 sec
      Start 35: koinos_tests-thunk_tests/check_authority
32/48 Test #30: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.10 sec
      Start 34: koinos_tests-thunk_tests/stack_tests
33/48 Test #23: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.28 sec
      Start 37: koinos_tests-thunk_tests/get_contract_id_test
34/48 Test #31: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.15 sec
      Start 29: koinos_tests-thunk_tests/system_call_test
35/48 Test #35: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.08 sec
      Start 21: koinos_tests-state_db_tests/rocksdb_object_cache_test
36/48 Test #32: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.15 sec
      Start 19: koinos_tests-state_db_tests/merkle_root_test
37/48 Test #34: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.12 sec
      Start 22: koinos_tests-state_db_tests/map_backend_test
38/48 Test #21: koinos_tests-state_db_tests/rocksdb_object_cache_test .............   Passed    0.07 sec
      Start 44: koinos_tests-thunk_tests/system_resources
39/48 Test #29: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.09 sec
      Start 18: koinos_tests-state_db_tests/anonymous_node_test
40/48 Test #25: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.29 sec
      Start 14: koinos_tests-state_db_tests/basic_test
41/48 Test #41: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.30 sec
42/48 Test #18: koinos_tests-state_db_tests/anonymous_node_test ...................   Passed    0.07 sec
43/48 Test #14: koinos_tests-state_db_tests/basic_test ............................   Passed    0.07 sec
44/48 Test #22: koinos_tests-state_db_tests/map_backend_test ......................   Passed    0.12 sec
45/48 Test #37: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.24 sec
46/48 Test #19: koinos_tests-state_db_tests/merkle_root_test ......................   Passed    0.14 sec
47/48 Test #44: koinos_tests-thunk_tests/system_resources .........................   Passed    0.14 sec
48/48 Test #48: koinos_tests-thunk_tests/thunk_time ...............................   Passed    3.98 sec

100% tests passed, 0 tests failed out of 48

Total Test time (real) =   3.98 sec
```