### PR TITLE
Fix assert_permissions

### DIFF
--- a/libraries/chain/state.cpp
+++ b/libraries/chain/state.cpp
@@ -116,18 +116,14 @@ const object_space transaction_nonce()
 
 void assert_permissions( execution_context& context, const object_space& space )
 {
-   auto privilege = context.get_privilege();
-   const auto& caller = context.get_caller();
-   if ( space.zone() != caller )
+   if ( context.get_privilege() == privilege::kernel_mode )
    {
-      if ( context.get_privilege() == privilege::kernel_mode )
-      {
-         KOINOS_ASSERT( space.system(), insufficient_privileges_exception, "privileged code can only accessed system space" );
-      }
-      else
-      {
-         KOINOS_THROW( reversion_exception, "contract attempted access of non-contract database space" );
-      }
+      KOINOS_ASSERT( space.system(), reversion_exception, "privileged code can only access system space" );
+   }
+   else
+   {
+      KOINOS_ASSERT( !space.system(), insufficient_privileges_exception, "user code cannot access system space" );
+      KOINOS_ASSERT( space.zone() == context.get_caller(), reversion_exception, "user code cannot access other contract space" );
    }
 }
 

--- a/tests/include/koinos/tests/util.hpp
+++ b/tests/include/koinos/tests/util.hpp
@@ -1,29 +1,29 @@
 #pragma once
 
-#define KOINOS_CHECK_THROW( S, C )                                      \
-do                                                                      \
-{                                                                       \
-   try                                                                  \
-   {                                                                    \
-      S;                                                                \
-      BOOST_TEST(false, "koinos::exception not thrown when expected" ); \
-   }                                                                    \
-   catch ( const koinos::exception& e )                                 \
-   {                                                                    \
-      BOOST_TEST_REQUIRE( e.get_code() == C, "exception code is not " #C ", was " + std::to_string( e.get_code() ) ); \
-   }                                                                    \
+#define KOINOS_CHECK_THROW( S, C )                                                                             \
+do                                                                                                             \
+{                                                                                                              \
+   try                                                                                                         \
+   {                                                                                                           \
+      S;                                                                                                       \
+      BOOST_TEST(false, "koinos::exception not thrown when expected" );                                        \
+   }                                                                                                           \
+   catch ( const koinos::exception& e )                                                                        \
+   {                                                                                                           \
+      BOOST_TEST( e.get_code() == C, "exception code is not " #C ", was " + std::to_string( e.get_code() ) );  \
+   }                                                                                                           \
 } while( 0 );
 
-#define KOINOS_REQUIRE_THROW( S, C )                                             \
-do                                                                               \
-{                                                                                \
-   try                                                                           \
-   {                                                                             \
-      S;                                                                         \
-      BOOST_TEST_REQUIRE(false, "koinos::exception not thrown when expected" );  \
-   }                                                                             \
-   catch ( const koinos::exception& e )                                          \
-   {                                                                             \
+#define KOINOS_REQUIRE_THROW( S, C )                                                                                  \
+do                                                                                                                    \
+{                                                                                                                     \
+   try                                                                                                                \
+   {                                                                                                                  \
+      S;                                                                                                              \
+      BOOST_TEST_REQUIRE(false, "koinos::exception not thrown when expected" );                                       \
+   }                                                                                                                  \
+   catch ( const koinos::exception& e )                                                                               \
+   {                                                                                                                  \
       BOOST_TEST_REQUIRE( e.get_code() == C, "exception code is not " #C ", was " + std::to_string( e.get_code() ) ); \
-   }                                                                             \
+   }                                                                                                                  \
 } while( 0 );


### PR DESCRIPTION
Resolves koinos/koinos-internal#121

## Brief description

Fix incorrect db permissions and privilege escalation

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
$ ./tests/koinos_tests -t thunk_tests/db_permissions -l message
Running 1 test case...
2022-06-15 13:47:39.842113 (koinos_test.SB2Fh) [thunk_test.cpp:192] <info>: Wrote 6 genesis objects into new database
2022-06-15 13:47:39.842298 (koinos_test.SB2Fh) [thunk_test.cpp:203] <info>: Calculated chain ID: 0x12207a67443c9c196a3a11ecad695eef8e2b09c4ed5f09721a76a58755afcc63fbbb
2022-06-15 13:47:39.842431 (koinos_test.SB2Fh) [thunk_test.cpp:211] <info>: Wrote chain ID into new database
Test failure accessing user data outside your zone from user context
Test success accessing user data inside your zone from user context
Test failure accessing kernel data outside your zone from user context
Test failure accessing kernel data inside your zone from user context
Test failure accessing user data outside your zone from kernel context
Test failure accessing user data inside your zone from kernel context
Test success accessing kernel data outside your zone from kernel context
Test success accessing kernel data inside your zone from kernel context

*** No errors detected
```
