### PR TITLE
Ensure that block height is set on the block receipt

### DIFF
--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -204,6 +204,7 @@ std::pair< std::string, std::string > hash_compute_keys( crypto::multicodec id )
 void generate_receipt( execution_context& context, protocol::block_receipt& receipt, const protocol::block& block )
 {
    receipt.set_id( block.id() );
+   receipt.set_height( block.header().height() );
    receipt.set_disk_storage_used( context.resource_meter().disk_storage_used() );
    receipt.set_compute_bandwidth_used( context.resource_meter().compute_bandwidth_used() );
    receipt.set_network_bandwidth_used( context.resource_meter().network_bandwidth_used() );

--- a/tests/tests/controller_test.cpp
+++ b/tests/tests/controller_test.cpp
@@ -306,7 +306,9 @@ BOOST_AUTO_TEST_CASE( submission_tests )
    block_req.mutable_block()->set_id( util::converter::as< std::string >( koinos::crypto::hash( crypto::multicodec::sha2_256, block_req.block().header() ) ) );
    sign_block( *block_req.mutable_block(), _block_signing_private_key );
 
-   _controller.submit_block( block_req );
+   auto block_resp = _controller.submit_block( block_req );
+
+   BOOST_CHECK_EQUAL( 1, block_resp.receipt().height() );
 
    BOOST_TEST_MESSAGE( "Error when block is too old" );
 


### PR DESCRIPTION
Resolves #638

## Brief description
Block height is now set on the block receipt properly.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ctest -j9
Test project /Users/sgerbino/Projects/koinos-chain/build/tests
      Start  1: koinos_tests-controller_tests/submission_tests
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  4: koinos_tests-controller_tests/read_contract_tests
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start  6: koinos_tests-controller_tests/receipt_test
      Start  7: koinos_tests-controller_tests/system_call_override_test
      Start  8: koinos_tests-stack_tests/simple_user_contract
      Start  9: koinos_tests-stack_tests/syscall_from_user
 1/51 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.14 sec
      Start 10: koinos_tests-stack_tests/user_from_user
 2/51 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.17 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
 3/51 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.19 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 4/51 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.19 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
 5/51 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.22 sec
      Start 14: koinos_tests-state_db_tests/basic_test
 6/51 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    0.30 sec
      Start 15: koinos_tests-state_db_tests/fork_tests
 7/51 Test #14: koinos_tests-state_db_tests/basic_test ............................   Passed    0.09 sec
      Start 16: koinos_tests-state_db_tests/merge_iterator
 8/51 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.21 sec
      Start 17: koinos_tests-state_db_tests/reset_test
 9/51 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.19 sec
      Start 18: koinos_tests-state_db_tests/anonymous_node_test
10/51 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.20 sec
      Start 19: koinos_tests-state_db_tests/merkle_root_test
11/51 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.21 sec
      Start 20: koinos_tests-state_db_tests/rocksdb_backend_test
12/51 Test #18: koinos_tests-state_db_tests/anonymous_node_test ...................   Passed    0.09 sec
      Start 21: koinos_tests-state_db_tests/rocksdb_object_cache_test
13/51 Test #16: koinos_tests-state_db_tests/merge_iterator ........................   Passed    0.16 sec
      Start 22: koinos_tests-state_db_tests/map_backend_test
14/51 Test #19: koinos_tests-state_db_tests/merkle_root_test ......................   Passed    0.10 sec
      Start 23: koinos_tests-thunk_tests/get_transaction_field
15/51 Test #20: koinos_tests-state_db_tests/rocksdb_backend_test ..................   Passed    0.14 sec
      Start 24: koinos_tests-thunk_tests/get_block_field
16/51 Test #17: koinos_tests-state_db_tests/reset_test ............................   Passed    0.21 sec
      Start 25: koinos_tests-thunk_tests/get_operation
17/51 Test #21: koinos_tests-state_db_tests/rocksdb_object_cache_test .............   Passed    0.09 sec
      Start 26: koinos_tests-thunk_tests/db_crud
18/51 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    0.57 sec
      Start 27: koinos_tests-thunk_tests/db_permissions
19/51 Test #22: koinos_tests-state_db_tests/map_backend_test ......................   Passed    0.09 sec
      Start 28: koinos_tests-thunk_tests/contract_tests
20/51 Test #15: koinos_tests-state_db_tests/fork_tests ............................   Passed    0.32 sec
      Start 29: koinos_tests-thunk_tests/override_tests
21/51 Test #23: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.13 sec
      Start 30: koinos_tests-thunk_tests/thunk_test
22/51 Test #25: koinos_tests-thunk_tests/get_operation ............................   Passed    0.11 sec
      Start 31: koinos_tests-thunk_tests/system_call_test
23/51 Test #24: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.13 sec
      Start 32: koinos_tests-thunk_tests/get_head_info_thunk_test
24/51 Test #26: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.12 sec
      Start 33: koinos_tests-thunk_tests/hash_thunk_test
25/51 Test #27: koinos_tests-thunk_tests/db_permissions ...........................   Passed    0.11 sec
      Start 34: koinos_tests-thunk_tests/privileged_calls
26/51 Test #30: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.11 sec
      Start 35: koinos_tests-thunk_tests/last_irreversible_block_test
27/51 Test #28: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.15 sec
      Start 36: koinos_tests-thunk_tests/stack_tests
28/51 Test #31: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.12 sec
      Start 37: koinos_tests-thunk_tests/check_authority
29/51 Test #33: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.11 sec
      Start 38: koinos_tests-thunk_tests/transaction_nonce_test
30/51 Test #32: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.12 sec
      Start 39: koinos_tests-thunk_tests/get_contract_id_test
31/51 Test #34: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.12 sec
      Start 40: koinos_tests-thunk_tests/token_tests
32/51 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    0.82 sec
      Start 41: koinos_tests-thunk_tests/call_contract_operation_failure
33/51 Test #29: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.21 sec
      Start 42: koinos_tests-thunk_tests/tick_limit
34/51 Test #36: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.10 sec
      Start 43: koinos_tests-thunk_tests/disk_usage
35/51 Test #37: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.12 sec
      Start 44: koinos_tests-thunk_tests/transaction_reversion
36/51 Test #35: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.18 sec
      Start 45: koinos_tests-thunk_tests/authorize_tests
37/51 Test #39: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.13 sec
      Start 46: koinos_tests-thunk_tests/get_chain_id
38/51 Test #38: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.14 sec
      Start 47: koinos_tests-thunk_tests/system_resources
39/51 Test #43: koinos_tests-thunk_tests/disk_usage ...............................   Passed    0.13 sec
      Start 48: koinos_tests-thunk_tests/system_rc
40/51 Test #46: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.11 sec
      Start 49: koinos_tests-thunk_tests/contract_exit
41/51 Test #47: koinos_tests-thunk_tests/system_resources .........................   Passed    0.11 sec
      Start 50: koinos_tests-thunk_tests/syscall_override_return
42/51 Test #44: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.13 sec
      Start 51: koinos_tests-thunk_tests/thunk_time
43/51 Test #42: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.22 sec
44/51 Test #41: koinos_tests-thunk_tests/call_contract_operation_failure ..........   Passed    0.26 sec
45/51 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    1.10 sec
46/51 Test #50: koinos_tests-thunk_tests/syscall_override_return ..................   Passed    0.14 sec
47/51 Test #40: koinos_tests-thunk_tests/token_tests ..............................   Passed    0.38 sec
48/51 Test #48: koinos_tests-thunk_tests/system_rc ................................   Passed    0.22 sec
49/51 Test #49: koinos_tests-thunk_tests/contract_exit ............................   Passed    0.17 sec
50/51 Test #45: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    0.38 sec
51/51 Test #51: koinos_tests-thunk_tests/thunk_time ...............................   Passed    1.95 sec

100% tests passed, 0 tests failed out of 51

Total Test time (real) =   3.00 sec
```
