### PR TITLE
Enforce valid utf-8 for log system calls

### DIFF
--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -1094,6 +1094,7 @@ THUNK_DEFINE( get_prev_object_result, get_prev_object, ((const object_space&) sp
 
 THUNK_DEFINE( void, log, ((const std::string&) msg) )
 {
+   KOINOS_ASSERT( validate_utf( msg ), reversion_exception, "log entry contains invalid utf-8" );
    context.chronicler().push_log( msg );
 }
 


### PR DESCRIPTION
## Brief description
Throw a reversion when invalid utf-8 is passed to the log system call.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

