### PR TITLE
Fix "iterator erroneosly hit null value in cache"

### DIFF
--- a/libraries/state_db/backends/rocksdb/rocksdb_iterator.cpp
+++ b/libraries/state_db/backends/rocksdb/rocksdb_iterator.cpp
@@ -109,7 +109,8 @@ void rocksdb_iterator::update_cache_value() const
       std::lock_guard< std::mutex > lock( _cache->get_mutex() );
       auto [cache_hit, ptr] = _cache->get( *key );
 
-      KOINOS_ASSERT( cache_hit, rocksdb_internal_exception, "iterator erroneosly hit null value in cache" );
+      if ( cache_hit )
+         KOINOS_ASSERT( ptr, rocksdb_internal_exception, "iterator erroneosly hit null value in cache" );
 
       if ( !ptr )
       {

--- a/libraries/state_db/backends/rocksdb/rocksdb_iterator.cpp
+++ b/libraries/state_db/backends/rocksdb/rocksdb_iterator.cpp
@@ -110,7 +110,7 @@ void rocksdb_iterator::update_cache_value() const
       auto [cache_hit, ptr] = _cache->get( *key );
 
       if ( cache_hit )
-         KOINOS_ASSERT( ptr, rocksdb_internal_exception, "iterator erroneosly hit null value in cache" );
+         KOINOS_ASSERT( ptr, rocksdb_internal_exception, "iterator erroneously hit null value in cache" );
 
       if ( !ptr )
       {

--- a/tests/tests/state_db_test.cpp
+++ b/tests/tests/state_db_test.cpp
@@ -1108,4 +1108,48 @@ BOOST_AUTO_TEST_CASE( fork_resolution )
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
+BOOST_AUTO_TEST_CASE( restart_cache )
+{ try {
+
+   crypto::multihash state_id = crypto::hash( crypto::multicodec::sha2_256, 1 );
+   auto state_1 = db.create_writable_node( db.get_head()->id(), state_id );
+   BOOST_REQUIRE( state_1 );
+
+   object_space space;
+   std::string a_key = "a";
+   std::string a_val = "alice";
+
+   chain::database_key db_key;
+   *db_key.mutable_space() = space;
+   db_key.set_key( a_key );
+
+   state_1->put_object( space, a_key, &a_val );
+
+   {
+      auto [ptr, key] = state_1->get_next_object( space, std::string() );
+
+      BOOST_REQUIRE( ptr );
+      BOOST_CHECK_EQUAL( *ptr, a_val );
+      BOOST_CHECK_EQUAL( key, a_key );
+   }
+
+   db.finalize_node( state_id );
+   state_1.reset();
+
+   db.commit_node( state_id );
+
+   db.close();
+   db.open( temp );
+
+   state_1 = db.get_root();
+   {
+      auto [ptr, key] = state_1->get_next_object( space, std::string() );
+
+      BOOST_REQUIRE( ptr );
+      BOOST_CHECK_EQUAL( *ptr, a_val );
+      BOOST_CHECK_EQUAL( key, a_key );
+   }
+
+} KOINOS_CATCH_LOG_AND_RETHROW(info) }
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Brief description

Fixes caching bug that prevents node from starting after shut down

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

