### PR TITLE
LIB handling

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -261,6 +261,7 @@ rpc::chain::submit_block_response controller_impl::submit_block(
    if ( !parent_node )
    {
       auto root = _db.get_root( db_lock );
+      KOINOS_ASSERT( block_height >= root->revision(), pre_irreversibility_block_exception, "block is prior to irreversibility" );
       KOINOS_ASSERT( block_id == root->id(), unknown_previous_block_exception, "unknown previous block" );
       return {}; // Block is current LIB
    }

--- a/libraries/chain/include/koinos/chain/exceptions.hpp
+++ b/libraries/chain/include/koinos/chain/exceptions.hpp
@@ -42,5 +42,6 @@ KOINOS_DECLARE_DERIVED_EXCEPTION_WITH_CODE( indexer_failure_exception, failure_e
 KOINOS_DECLARE_DERIVED_EXCEPTION_WITH_CODE( network_bandwidth_limit_exceeded_exception, failure_exception, network_bandwidth_limit_exceeded );
 KOINOS_DECLARE_DERIVED_EXCEPTION_WITH_CODE( compute_bandwidth_limit_exceeded_exception, failure_exception, compute_bandwidth_limit_exceeded );
 KOINOS_DECLARE_DERIVED_EXCEPTION_WITH_CODE( disk_storage_limit_exceeded_exception, failure_exception, disk_storage_limit_exceeded );
+KOINOS_DECLARE_DERIVED_EXCEPTION_WITH_CODE( pre_irreversibility_block_exception, failure_exception, pre_irreversibility_block );
 
 } // koinos::chain


### PR DESCRIPTION
Related to koinos/koinos-p2p#222.

## Brief description
Add a specific error code for attempted block applications with parents prior to last irreversible block.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
...
2022-09-06 15:31:54.118857 (koinos_test.p3sET) [controller.cpp:273] <info>: Pushing block - Height: 63, ID: 0x122063b9b0407fe8395f2ab2e8625fe6a8c418294c9b7f95da52b70cebe4286d84a3
2022-09-06 15:31:54.120135 (koinos_test.p3sET) [controller.cpp:357] <info>: Block application successful - Height: 63, ID: 0x122063b9b0407fe8395f2ab2e8625fe6a8c418294c9b7f95da52b70cebe4286d84a3 (0 transactions)
2022-09-06 15:31:54.120222 (koinos_test.p3sET) [controller.cpp:358] <info>: Consumed resources: 0 disk, 222 network, 59599 compute
Check parent pre block irreversibility submission
Check parent unknown block at LIB height

*** No errors detected
```
