### PR TITLE
Fix old LIB Commit

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -436,7 +436,15 @@ rpc::chain::submit_block_response controller_impl::submit_block(
          parent_node.reset();
          ctx.clear_state_node();
 
-         _db.commit_node( lib_id, _db.get_unique_lock() );
+         // There is a race condition where the LIB from a later block can be updated,
+         // resulting in a failure to commit the LIB on an earlier block. If that happens,
+         // ignore the exception
+         try 
+         {
+            _db.commit_node( lib_id, _db.get_unique_lock() );
+         }
+         catch ( const state_db::illegal_argument& ) { /* do nothing */ }
+         
 
          db_lock = _db.get_shared_lock();
       }


### PR DESCRIPTION
## Brief description

Fixes a race condition where an old LIB can be committed and throw an exception, appearing as a block failure.

## Checklist

- [ X I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
