### PR TITLE
Handle specific case when state node could not be created

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -454,6 +454,11 @@ rpc::chain::submit_block_response controller_impl::submit_block(
          db_lock = _db.get_shared_lock();
       }
    }
+   catch ( block_state_error_exception& e )
+   {
+      LOG(warning) << "Block application failed - Height: " << block_height << " ID: " << block_id << ", with reason: " << e.what();
+      throw;
+   }
    catch ( koinos::exception& e )
    {
       if ( block_node && !block_node->is_finalized() )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -454,7 +454,7 @@ rpc::chain::submit_block_response controller_impl::submit_block(
          db_lock = _db.get_shared_lock();
       }
    }
-   catch ( block_state_error_exception& e )
+   catch ( const block_state_error_exception& e )
    {
       LOG(warning) << "Block application failed - Height: " << block_height << " ID: " << block_id << ", with reason: " << e.what();
       throw;

--- a/libraries/state_db/state_db.cpp
+++ b/libraries/state_db/state_db.cpp
@@ -328,7 +328,7 @@ state_node_ptr database_impl::create_writable_node( const state_node_id& parent_
    // Needs to be configurable
    auto timeout = std::chrono::system_clock::now() + std::chrono::seconds( 1 );
 
-   state_node_ptr parent_state = get_node_lockless( parent_id );
+   state_node_ptr parent_state = get_node( parent_id, lock );
 
    if ( parent_state )
    {


### PR DESCRIPTION
Resolves #760.

## Brief description
Grab read lock when grabbing the parent state node. Handle the specific error case when the state node cannot be created.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
