### PR TITLE
Prevent calling authorization from user code and test protections

### DIFF
--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -1271,6 +1271,11 @@ THUNK_DEFINE( call_result, call, ((const std::string&) contract_id, (uint32_t) e
    auto contract_meta = util::converter::to< contract_metadata_object >( contract_meta_object.value() );
    KOINOS_ASSERT( contract_meta.hash().size(), invalid_contract_exception, "contract hash does not exist" );
 
+   if ( entry_point == authorize_entrypoint )
+   {
+      KOINOS_ASSERT( context.get_caller_privilege() == privilege::kernel_mode, insufficient_privileges_exception, "calling privileged thunk from non-privileged code" );
+   }
+
    try
    {
       with_stack_frame(

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -1271,10 +1271,8 @@ THUNK_DEFINE( call_result, call, ((const std::string&) contract_id, (uint32_t) e
    auto contract_meta = util::converter::to< contract_metadata_object >( contract_meta_object.value() );
    KOINOS_ASSERT( contract_meta.hash().size(), invalid_contract_exception, "contract hash does not exist" );
 
-   if ( entry_point == authorize_entrypoint )
-   {
-      KOINOS_ASSERT( context.get_caller_privilege() == privilege::kernel_mode, insufficient_privileges_exception, "calling privileged thunk from non-privileged code" );
-   }
+   // authorize should only be called from kernel mode
+   KOINOS_ASSERT( entry_point != authorize_entrypoint || context.get_caller_privilege() == privilege::kernel_mode, insufficient_privileges_exception, "calling privileged thunk from non-privileged code" );
 
    try
    {


### PR DESCRIPTION
Resolves #765

## Brief description

Prevent calling authorization from user code and test protections

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
$ ./tests/koinos_tests -t thunk_tests/authorize_tests -l message
Running 1 test case...
2022-10-11 13:18:36.922690 (koinos_test.tEO04) [thunk_test.cpp:195] <info>: Wrote 6 genesis objects into new database
2022-10-11 13:18:36.922719 (koinos_test.tEO04) [thunk_test.cpp:206] <info>: Calculated chain ID: 0x12205f4d92b71c7d282e85b269e1b17d2c3522fc2df55eb3052aeb6c1db221980cda
2022-10-11 13:18:36.922736 (koinos_test.tEO04) [thunk_test.cpp:214] <info>: Wrote chain ID into new database
Override authorize call contract
Transfer from 'a' to 'b'
Override authorize upload contract
Override authorize use rc
Try calling authorize directly

*** No errors detected
```
