### PR TITLE
Do not include events from reverted transactions

### DIFF
--- a/libraries/chain/session.cpp
+++ b/libraries/chain/session.cpp
@@ -8,7 +8,7 @@ session::~session() = default;
 
 void session::use_rc( int64_t rc )
 {
-   KOINOS_ASSERT( rc <= _end_rc, insufficient_rc_exception, "insufficent rc" );
+   KOINOS_ASSERT( rc <= _end_rc, insufficient_rc_exception, "insufficient rc" );
    _end_rc -= rc;
 }
 

--- a/libraries/chain/system_calls.cpp
+++ b/libraries/chain/system_calls.cpp
@@ -599,7 +599,7 @@ THUNK_DEFINE( void, apply_transaction, ((const protocol::transaction&) trx) )
          // If the transaction fails for any other reason within the operations, it is reverted.
          // Mana is still charged, but the block does not fail
          receipt.set_reverted( true );
-         system_call::log( context, e.get_message() );
+         thunk::_log( context, "transaction reverted: " + e.get_message() );
          reverted_exception_ptr = std::current_exception();
       }
       catch ( const std::exception& e )

--- a/tests/tests/controller_test.cpp
+++ b/tests/tests/controller_test.cpp
@@ -784,7 +784,9 @@ BOOST_AUTO_TEST_CASE( transaction_reversion_test )
 
    BOOST_REQUIRE_EQUAL( resp.receipt().transaction_receipts(2).id(), trx5.id() );
    BOOST_REQUIRE_EQUAL( resp.receipt().transaction_receipts(2).reverted(), true );
+   BOOST_REQUIRE_EQUAL( resp.receipt().transaction_receipts(2).logs().size(), 2 );
    BOOST_REQUIRE_EQUAL( resp.receipt().transaction_receipts(2).logs(0), "Greetings from koinos vm" );
+   BOOST_REQUIRE_EQUAL( resp.receipt().transaction_receipts(2).logs(1), "transaction reverted: insufficient rc" );
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 


### PR DESCRIPTION
## Brief description
We do not include events from reverted transactions, in addition we include the reason for the reversion to the logs on the transaction receipt.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

