### PR TITLE
Patch code based on static analysis results

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -348,10 +348,6 @@ rpc::chain::submit_block_response controller_impl::submit_block(
          KOINOS_ASSERT( resp.has_add_block(), rpc_failure_exception, "unexpected response when submitting block: ${r}", ("r", resp) );
       }
 
-      uint64_t disk_storage_used      = ctx.resource_meter().disk_storage_used();
-      uint64_t network_bandwidth_used = ctx.resource_meter().network_bandwidth_used();
-      uint64_t compute_bandwidth_used = ctx.resource_meter().compute_bandwidth_used();
-
       if ( !index_to && live )
       {
          auto num_transactions = block.transactions_size();
@@ -559,10 +555,6 @@ rpc::chain::submit_transaction_response controller_impl::submit_transaction( con
       ctx.resource_meter().set_resource_limit_data( system_call::get_resource_limits( ctx ) );
 
       system_call::apply_transaction( ctx, transaction );
-
-      uint64_t disk_storage_used      = ctx.resource_meter().disk_storage_used();
-      uint64_t network_bandwidth_used = ctx.resource_meter().network_bandwidth_used();
-      uint64_t compute_bandwidth_used = ctx.resource_meter().compute_bandwidth_used();
 
       if ( _client )
       {

--- a/libraries/vm_manager/fizzy/fizzy_vm_backend.cpp
+++ b/libraries/vm_manager/fizzy/fizzy_vm_backend.cpp
@@ -114,9 +114,9 @@ module_ptr parse_bytecode( const char* bytecode_data, size_t bytecode_size )
 {
    FizzyError fizzy_err;
    KOINOS_ASSERT( bytecode_data != nullptr, fizzy_returned_null_exception, "fizzy_instance was unexpectedly null pointer" );
-   auto ptr = fizzy_parse(reinterpret_cast< const uint8_t* >( bytecode_data ), bytecode_size, nullptr);
+   auto ptr = fizzy_parse( reinterpret_cast< const uint8_t* >( bytecode_data ), bytecode_size, &fizzy_err );
 
-   if ( ptr == nullptr)
+   if ( ptr == nullptr )
    {
       std::string error_code = fizzy_error_code_name( fizzy_err.code );
       std::string error_message = fizzy_err.message;

--- a/tests/tests/controller_test.cpp
+++ b/tests/tests/controller_test.cpp
@@ -393,7 +393,6 @@ BOOST_AUTO_TEST_CASE( block_irreversibility )
    start_time = std::chrono::system_clock::now().time_since_epoch();
    for ( uint64_t i = chain::default_irreversible_threshold + 1; i <= chain::default_irreversible_threshold + 3; i++ )
    {
-      auto duration = std::chrono::system_clock::now().time_since_epoch();
       block_req.mutable_block()->mutable_header()->set_timestamp( std::chrono::duration_cast< std::chrono::milliseconds >( start_time + std::chrono::milliseconds{ i } ).count() );
       block_req.mutable_block()->mutable_header()->set_height( head_info_res.head_topology().height() + 1 );
       block_req.mutable_block()->mutable_header()->set_previous( head_info_res.head_topology().id() );

--- a/tests/tests/thunk_test.cpp
+++ b/tests/tests/thunk_test.cpp
@@ -2103,6 +2103,8 @@ BOOST_AUTO_TEST_CASE( syscall_override_return )
 
 } KOINOS_CATCH_LOG_AND_RETHROW(info) }
 
+#define THUNK_TIME_PRINT_STATS false
+
 BOOST_AUTO_TEST_CASE( thunk_time )
 { try {
    crypto::multihash contract_seed = crypto::hash( crypto::multicodec::sha2_256, std::string{ "contract" } );
@@ -2160,8 +2162,10 @@ BOOST_AUTO_TEST_CASE( thunk_time )
          auto session = ctx.make_session( 1'000'000 );
 
          uint64_t compute_bandwidth_start = ctx.resource_meter().compute_bandwidth_used();
+#if THUNK_TIME_PRINT_STATS
          uint64_t network_bandwidth_start = ctx.resource_meter().network_bandwidth_used();
          uint64_t disk_storage_start      = ctx.resource_meter().disk_storage_used();
+#endif
 
          chain::host_api hapi( ctx );
          auto hash = util::converter::as< std::string >( crypto::multihash::empty( crypto::multicodec::sha2_256 ) );
@@ -2175,20 +2179,26 @@ BOOST_AUTO_TEST_CASE( thunk_time )
          auto stop = std::chrono::high_resolution_clock::now();
 
          uint64_t compute_bandwidth_stop = ctx.resource_meter().compute_bandwidth_used();
+#if THUNK_TIME_PRINT_STATS
          uint64_t network_bandwidth_stop = ctx.resource_meter().network_bandwidth_used();
          uint64_t disk_storage_stop      = ctx.resource_meter().disk_storage_used();
+#endif
 
          uint64_t compute_used = compute_bandwidth_stop - compute_bandwidth_start;
+#if THUNK_TIME_PRINT_STATS
          uint64_t network_used = network_bandwidth_stop - network_bandwidth_start;
          uint64_t disk_used = disk_storage_stop - disk_storage_start;
+#endif
 
          auto duration = std::chrono::duration_cast< std::chrono::nanoseconds >( stop - start );
-         //LOG(info) << "benchmark contract took: " << duration.count() << "us";
-         //LOG(info) << " -> compute: " << compute_used;
-         //LOG(info) << " -> network: " << network_used;
-         //LOG(info) << " -> disk: " << disk_used;
+#if THUNK_TIME_PRINT_STATS
+         LOG(info) << "benchmark contract took: " << duration.count() << "us";
+         LOG(info) << " -> compute: " << compute_used;
+         LOG(info) << " -> network: " << network_used;
+         LOG(info) << " -> disk: " << disk_used;
+         LOG(info) << " -> approximate nanoseconds per compute: " << compute_used / double( duration.count() );
+#endif
          benchmarks.push_back( compute_used / double( duration.count() ) );
-         //LOG(info) << " -> approximate nanoseconds per compute: " << compute_used / double( duration.count() );
       }
       catch ( const koinos::exception& e )
       {


### PR DESCRIPTION
Resolves #784.

## Brief description
Removes unused variables. Uses macros to avoid compilation of unused additional logging. Properly pass the address of a `fizzy_error` to retrieve the appropriate error message.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
Test project /Users/sgerbino/Projects/koinos-chain/build/tests
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start  9: koinos_tests-stack_tests/syscall_from_user
      Start  8: koinos_tests-stack_tests/simple_user_contract
      Start  6: koinos_tests-controller_tests/receipt_test
      Start  1: koinos_tests-controller_tests/submission_tests
      Start  7: koinos_tests-controller_tests/system_call_override_test
      Start  4: koinos_tests-controller_tests/read_contract_tests
 1/42 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.07 sec
      Start 42: koinos_tests-thunk_tests/thunk_time
 2/42 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.08 sec
      Start 20: koinos_tests-thunk_tests/override_tests
 3/42 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.07 sec
      Start 31: koinos_tests-thunk_tests/token_tests
 4/42 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.08 sec
      Start 36: koinos_tests-thunk_tests/authorize_tests
 5/42 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    0.08 sec
      Start 19: koinos_tests-thunk_tests/contract_tests
 6/42 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.08 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
 7/42 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    0.14 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 8/42 Test #19: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.06 sec
      Start 26: koinos_tests-thunk_tests/last_irreversible_block_test
 9/42 Test #31: koinos_tests-thunk_tests/token_tests ..............................   Passed    0.07 sec
      Start 18: koinos_tests-thunk_tests/db_permissions
10/42 Test #20: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.08 sec
      Start 25: koinos_tests-thunk_tests/privileged_calls
11/42 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    0.16 sec
      Start 37: koinos_tests-thunk_tests/get_chain_id
12/42 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.08 sec
      Start 29: koinos_tests-thunk_tests/transaction_nonce_test
13/42 Test #26: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.06 sec
      Start 39: koinos_tests-thunk_tests/system_rc
14/42 Test #18: koinos_tests-thunk_tests/db_permissions ...........................   Passed    0.06 sec
      Start 33: koinos_tests-thunk_tests/tick_limit
15/42 Test #25: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.06 sec
      Start 14: koinos_tests-thunk_tests/get_transaction_field
16/42 Test #37: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.07 sec
      Start 15: koinos_tests-thunk_tests/get_block_field
17/42 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.10 sec
      Start 28: koinos_tests-thunk_tests/check_authority
18/42 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    0.24 sec
      Start 35: koinos_tests-thunk_tests/transaction_reversion
19/42 Test #36: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    0.16 sec
      Start 27: koinos_tests-thunk_tests/stack_tests
20/42 Test #29: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.08 sec
      Start 38: koinos_tests-thunk_tests/system_resources
21/42 Test #14: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.06 sec
      Start 32: koinos_tests-thunk_tests/call_contract_operation_failure
22/42 Test #33: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.08 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
23/42 Test #28: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.07 sec
      Start 30: koinos_tests-thunk_tests/get_contract_id_test
24/42 Test #35: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.07 sec
      Start 10: koinos_tests-stack_tests/user_from_user
25/42 Test #27: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.07 sec
      Start 40: koinos_tests-thunk_tests/contract_exit
26/42 Test #15: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.09 sec
      Start 24: koinos_tests-thunk_tests/hash_thunk_test
27/42 Test #39: koinos_tests-thunk_tests/system_rc ................................   Passed    0.11 sec
      Start 41: koinos_tests-thunk_tests/syscall_override_return
28/42 Test #38: koinos_tests-thunk_tests/system_resources .........................   Passed    0.08 sec
      Start 34: koinos_tests-thunk_tests/disk_usage
29/42 Test #30: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.06 sec
      Start 16: koinos_tests-thunk_tests/get_operation
30/42 Test #32: koinos_tests-thunk_tests/call_contract_operation_failure ..........   Passed    0.09 sec
      Start 23: koinos_tests-thunk_tests/get_head_info_thunk_test
31/42 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.08 sec
      Start 22: koinos_tests-thunk_tests/system_call_test
32/42 Test #40: koinos_tests-thunk_tests/contract_exit ............................   Passed    0.08 sec
      Start 21: koinos_tests-thunk_tests/thunk_test
33/42 Test #34: koinos_tests-thunk_tests/disk_usage ...............................   Passed    0.07 sec
      Start 17: koinos_tests-thunk_tests/db_crud
34/42 Test #41: koinos_tests-thunk_tests/syscall_override_return ..................   Passed    0.07 sec
35/42 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.10 sec
36/42 Test #24: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.09 sec
37/42 Test #16: koinos_tests-thunk_tests/get_operation ............................   Passed    0.06 sec
38/42 Test #23: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.06 sec
39/42 Test #22: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.06 sec
40/42 Test #21: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.06 sec
41/42 Test #17: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.05 sec
42/42 Test #42: koinos_tests-thunk_tests/thunk_time ...............................   Passed    0.59 sec

100% tests passed, 0 tests failed out of 42

Total Test time (real) =   0.68 sec

```
