### PR TITLE
Remove redundant copies where possible

### DIFF
--- a/libraries/chain/host_api.cpp
+++ b/libraries/chain/host_api.cpp
@@ -82,7 +82,6 @@ int32_t host_api::invoke_system_call( uint32_t sid, char* ret_ptr, uint32_t ret_
          [&]() {
             if ( _ctx.system_call_exists( sid ) )
             {
-               #pragma message "TODO: Brainstorm how to avoid arg/ret copy and validate pointers"
                std::string args( arg_ptr, arg_len );
                auto res = _ctx.system_call( sid, args );
                code = res.code;


### PR DESCRIPTION
Resolves #473.

## Brief description
Utilize `SerializeToArray` and `ParseFromArray` to remove extraneous copies to/from strings.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```console
❯ ctest -j9
Test project /Users/sgerbino/Projects/koinos-chain/build/tests
      Start 42: koinos_tests-thunk_tests/thunk_time
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start  6: koinos_tests-controller_tests/receipt_test
      Start  9: koinos_tests-stack_tests/syscall_from_user
      Start  4: koinos_tests-controller_tests/read_contract_tests
      Start  8: koinos_tests-stack_tests/simple_user_contract
      Start  7: koinos_tests-controller_tests/system_call_override_test
 1/42 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.16 sec
      Start 36: koinos_tests-thunk_tests/authorize_tests
 2/42 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.16 sec
      Start  1: koinos_tests-controller_tests/submission_tests
 3/42 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.17 sec
      Start 31: koinos_tests-thunk_tests/token_tests
 4/42 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.18 sec
      Start 32: koinos_tests-thunk_tests/call_contract_operation_failure
 5/42 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    0.24 sec
      Start 39: koinos_tests-thunk_tests/system_rc
 6/42 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.11 sec
      Start 33: koinos_tests-thunk_tests/tick_limit
 7/42 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    0.34 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 8/42 Test #32: koinos_tests-thunk_tests/call_contract_operation_failure ..........   Passed    0.19 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
 9/42 Test #31: koinos_tests-thunk_tests/token_tests ..............................   Passed    0.25 sec
      Start 40: koinos_tests-thunk_tests/contract_exit
10/42 Test #33: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.16 sec
      Start 10: koinos_tests-stack_tests/user_from_user
11/42 Test #39: koinos_tests-thunk_tests/system_rc ................................   Passed    0.20 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
12/42 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.17 sec
      Start 30: koinos_tests-thunk_tests/get_contract_id_test
13/42 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    0.53 sec
      Start 41: koinos_tests-thunk_tests/syscall_override_return
14/42 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.17 sec
      Start 20: koinos_tests-thunk_tests/override_tests
15/42 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    0.57 sec
      Start 14: koinos_tests-thunk_tests/get_transaction_field
16/42 Test #40: koinos_tests-thunk_tests/contract_exit ............................   Passed    0.17 sec
      Start 35: koinos_tests-thunk_tests/transaction_reversion
17/42 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.16 sec
      Start 19: koinos_tests-thunk_tests/contract_tests
18/42 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.17 sec
      Start 15: koinos_tests-thunk_tests/get_block_field
19/42 Test #30: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.11 sec
      Start 34: koinos_tests-thunk_tests/disk_usage
20/42 Test #41: koinos_tests-thunk_tests/syscall_override_return ..................   Passed    0.16 sec
      Start 22: koinos_tests-thunk_tests/system_call_test
21/42 Test #14: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.12 sec
      Start 29: koinos_tests-thunk_tests/transaction_nonce_test
22/42 Test #35: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.12 sec
      Start 28: koinos_tests-thunk_tests/check_authority
23/42 Test #20: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.16 sec
      Start 38: koinos_tests-thunk_tests/system_resources
24/42 Test #19: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.14 sec
      Start 27: koinos_tests-thunk_tests/stack_tests
25/42 Test #36: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    0.59 sec
      Start 26: koinos_tests-thunk_tests/last_irreversible_block_test
26/42 Test #34: koinos_tests-thunk_tests/disk_usage ...............................   Passed    0.12 sec
      Start 23: koinos_tests-thunk_tests/get_head_info_thunk_test
27/42 Test #15: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.15 sec
      Start 25: koinos_tests-thunk_tests/privileged_calls
28/42 Test #22: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.13 sec
      Start 18: koinos_tests-thunk_tests/db_permissions
29/42 Test #28: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.12 sec
      Start 24: koinos_tests-thunk_tests/hash_thunk_test
30/42 Test #38: koinos_tests-thunk_tests/system_resources .........................   Passed    0.12 sec
      Start 17: koinos_tests-thunk_tests/db_crud
31/42 Test #29: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.14 sec
      Start 21: koinos_tests-thunk_tests/thunk_test
32/42 Test #26: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.12 sec
      Start 16: koinos_tests-thunk_tests/get_operation
33/42 Test #27: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.14 sec
      Start 37: koinos_tests-thunk_tests/get_chain_id
34/42 Test #23: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.14 sec
35/42 Test #25: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.14 sec
36/42 Test #24: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.11 sec
37/42 Test #18: koinos_tests-thunk_tests/db_permissions ...........................   Passed    0.13 sec
38/42 Test #17: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.12 sec
39/42 Test #21: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.12 sec
40/42 Test #16: koinos_tests-thunk_tests/get_operation ............................   Passed    0.10 sec
41/42 Test #37: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.10 sec
42/42 Test #42: koinos_tests-thunk_tests/thunk_time ...............................   Passed    1.94 sec

100% tests passed, 0 tests failed out of 42

Total Test time (real) =   1.94 sec
```
