### PR TITLE
Add logs to exception on `read_contract` error

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -794,7 +794,17 @@ rpc::chain::read_contract_response controller_impl::read_contract( const rpc::ch
    ctx.resource_meter().set_resource_limit_data( rl );
 
    rpc::chain::read_contract_response resp;
-   resp.set_result( system_call::call( ctx, request.contract_id(), request.entry_point(), request.args() ) );
+
+   try
+   {
+      resp.set_result( system_call::call( ctx, request.contract_id(), request.entry_point(), request.args() ) );
+   }
+   catch ( koinos::exception& e )
+   {
+      e.add_json( "logs", ctx.chronicler().logs() );
+      throw e;
+   }
+
 
    for ( const auto& message : ctx.chronicler().logs() )
       *resp.add_logs() = message;


### PR DESCRIPTION
Resolves #796

## Brief description
Add logs to exception on read_contract error

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
```
$ curl -d '{"jsonrpc":"2.0", "method":"chain.read_contract", "params":{"contract_id":"15AJB59oTTNConTu9krF7ZnjbmBydSnfYA"}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   255  100   135  100   120   8605   7649 --:--:-- --:--:-- --:--:-- 36428
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "reversion message",
    "data": "{\"code\":1,\"logs\":[\"log before an error\"]}"
  },
  "id": 0
}
```