### PR TITLE
Add invoke_system_call

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -843,7 +843,18 @@ rpc::chain::invoke_system_call_response controller_impl::invoke_system_call( con
    ctx.set_state_node( _db.get_head( _db.get_shared_lock() )->create_anonymous_node() );
    ctx.reset_cache();
 
-   auto res = ctx.system_call( request.system_call_id(), request.args() );
+   koinos::chain::execution_result res;
+   if (request.has_id())
+   {
+      res = ctx.system_call( request.id(), request.args() );
+   }
+   else
+   {
+      system_call_id val;
+      if (!system_call_id_Parse( request.name(), &val ))
+         KOINOS_THROW( unknown_system_call_exception, "Invalid system call name" );
+      res = ctx.system_call( val, request.args() );
+   }
 
    rpc::chain::invoke_system_call_response resp;
    resp.set_value( res.res.SerializeAsString() );

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -848,12 +848,16 @@ rpc::chain::invoke_system_call_response controller_impl::invoke_system_call( con
    {
       res = ctx.system_call( request.id(), request.args() );
    }
-   else
+   else if (request.has_name())
    {
       system_call_id val;
       if (!system_call_id_Parse( request.name(), &val ))
          KOINOS_THROW( unknown_system_call_exception, "Invalid system call name" );
       res = ctx.system_call( val, request.args() );
+   }
+   else
+   {
+      KOINOS_THROW( unknown_system_call_exception, "Missing system call id or name" );
    }
 
    rpc::chain::invoke_system_call_response resp;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -844,20 +844,20 @@ rpc::chain::invoke_system_call_response controller_impl::invoke_system_call( con
    ctx.reset_cache();
 
    koinos::chain::execution_result res;
-   if (request.has_id())
+   if ( request.has_id() )
    {
       res = ctx.system_call( request.id(), request.args() );
    }
-   else if (request.has_name())
+   else if ( request.has_name() )
    {
       system_call_id val;
-      if (!system_call_id_Parse( request.name(), &val ))
-         KOINOS_THROW( unknown_system_call_exception, "Invalid system call name" );
+      if ( !system_call_id_Parse( request.name(), &val ) )
+         KOINOS_THROW( unknown_system_call_exception, "unknown system call name" );
       res = ctx.system_call( val, request.args() );
    }
    else
    {
-      KOINOS_THROW( unknown_system_call_exception, "Missing system call id or name" );
+      KOINOS_THROW( unknown_system_call_exception, "missing system call id or name" );
    }
 
    rpc::chain::invoke_system_call_response resp;

--- a/libraries/chain/include/koinos/chain/controller.hpp
+++ b/libraries/chain/include/koinos/chain/controller.hpp
@@ -46,6 +46,7 @@ class controller final
       rpc::chain::get_account_nonce_response get_account_nonce( const rpc::chain::get_account_nonce_request& );
       rpc::chain::get_account_rc_response get_account_rc( const rpc::chain::get_account_rc_request& );
       rpc::chain::get_resource_limits_response get_resource_limits( const rpc::chain::get_resource_limits_request& );
+      rpc::chain::invoke_system_call_response invoke_system_call( const rpc::chain::invoke_system_call_request& );
 
    private:
       std::unique_ptr< detail::controller_impl > _my;

--- a/programs/koinos_chain/main.cpp
+++ b/programs/koinos_chain/main.cpp
@@ -366,6 +366,9 @@ void attach_request_handler(
                   case rpc::chain::chain_request::RequestCase::kGetResourceLimits:
                      *resp.mutable_get_resource_limits() = controller.get_resource_limits( args.get_resource_limits() );
                      break;
+                  case rpc::chain::chain_request::RequestCase::kInvokeSystemCall:
+                     *resp.mutable_invoke_system_call() = controller.invoke_system_call( args.invoke_system_call() );
+                     break;
                   default:
                      resp.mutable_error()->set_message( "Error: attempted to call unknown rpc" );
                      break;


### PR DESCRIPTION
Resolves #799

## Brief description
Add `invoke_system_call`

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

Invoking system call `get_contract_address`, using the name `koin`

```
curl -d '{"jsonrpc":"2.0", "method":"chain.invoke_system_call", "params":{"id":10001, "args":"CgRrb2lu"}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   208  100    90  100   118  45000  59000 --:--:-- --:--:-- --:--:--  101k
{
  "jsonrpc": "2.0",
  "result": {
    "value": "Ch0KGwoZAC4z_RqpB7IkzpzmyUIokB0oOgLalW2nkQ=="
  },
  "id": 0
}
```

This protobuf message is a result object containing the proper address.

Here is invoking it using the name of the system call:

```
curl -d '{"jsonrpc":"2.0", "method":"chain.invoke_system_call", "params":{"name":"get_contract_address", "args":"CgRrb2lu"}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   213  100    90  100   123  45000  61500 --:--:-- --:--:-- --:--:--  104k
{
  "jsonrpc": "2.0",
  "result": {
    "value": "Ch0KGwoZAC4z_RqpB7IkzpzmyUIokB0oOgLalW2nkQ=="
  },
  "id": 0
}
```

and invoking `get_resource_limits` via id, then name:

```
curl -d '{"jsonrpc":"2.0", "method":"chain.invoke_system_call", "params":{"name":"get_resource_limits"}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   185  100    82  100   103  41000  51500 --:--:-- --:--:-- --:--:-- 92500
{
  "jsonrpc": "2.0",
  "result": {
    "value": "ChkKFwiAgCAQkrABGICAQCDUGijgzYuJATAR"
  },
  "id": 0
}


curl -d '{"jsonrpc":"2.0", "method":"chain.invoke_system_call", "params":{"id":203}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   165  100    82  100    83  27333  27666 --:--:-- --:--:-- --:--:-- 55000
{
  "jsonrpc": "2.0",
  "result": {
    "value": "ChkKFwiAgCAQkrABGICAQCDUGijgzYuJATAR"
  },
  "id": 0
}
```

Invoking with no name or id:
```
 curl -d '{"jsonrpc":"2.0", "method":"chain.invoke_system_call", "params":{}, "id":0}' http://localhost:8080/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   191  100   116  100    75   113k  75000 --:--:-- --:--:-- --:--:--  186k
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "Missing system call id or name",
    "data": "{\"code\":-103}"
  },
  "id": 0
}
```
