### PR TITLE
Return attached object on result, rather than result itself

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -863,7 +863,7 @@ rpc::chain::invoke_system_call_response controller_impl::invoke_system_call( con
    }
 
    rpc::chain::invoke_system_call_response resp;
-   resp.set_value( res.res.SerializeAsString() );
+   resp.set_value( res.res.object() );
 
    return resp;
 }


### PR DESCRIPTION
## Brief description
Return the proper object in invoke system call

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration

VHP contract address, fetch via the `get_contract_address` system call using `invoke_system_call`:
```
2023-04-28 17:46:29.879405 (block_producer.Local-Koinos) [pob_producer.cpp:244] <info>: VHP contract address: 1Ak89pu1mGfha5EJgnMj2wa9EJRABurgwE
```
