### PR TITLE
Propose error

### DIFF
--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -293,8 +293,6 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
   static constexpr std::chrono::seconds time_delta = std::chrono::seconds( 5 );
   static constexpr std::chrono::seconds live_delta = std::chrono::seconds( 60 );
 
-  bool has_failed_transactions = false;
-
   auto time_lower_bound = uint64_t( 0 );
   auto time_upper_bound =
     std::chrono::duration_cast< std::chrono::milliseconds >( ( opts.application_time + time_delta ).time_since_epoch() )
@@ -393,8 +391,6 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
     {
       // Icky, but the transaction failure code is in a catch block
       // so use the current flow of control
-
-      has_failed_transactions = true;
 
       KOINOS_THROW( failure_exception,
                     "${n} transactions failed in the block",
@@ -569,7 +565,7 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
     if( std::holds_alternative< protocol::block_receipt >( ctx.receipt() ) )
       e.add_json( "logs", std::get< protocol::block_receipt >( ctx.receipt() ).logs() );
 
-    if( has_failed_transactions )
+    if( opts.propose_block && res.failed_transaction_indices.size() )
     {
       if( _client )
       {

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -498,6 +498,10 @@ BOOST_AUTO_TEST_CASE( propose_block )
     BOOST_REQUIRE_EQUAL( block_resp.failed_transaction_indices_size(), 2 );
     BOOST_REQUIRE_EQUAL( block_resp.failed_transaction_indices( 0 ), 0 );
     BOOST_REQUIRE_EQUAL( block_resp.failed_transaction_indices( 1 ), 2 );
+
+    // Sign the block with the wrong key to trigger a failure in system_call::apply_block
+    sign_block( *block_req.mutable_block(), key );
+    BOOST_REQUIRE_THROW( _controller.propose_block( block_req ), koinos::exception );
   }
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }


### PR DESCRIPTION
## Brief description

Throws correct error if non transaction based exception is thrown during apply_block.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

Without the fix:
```
❯ ctest
Test project /home/michael/dev/koinos-chain/build/tests
      Start  1: chain_tests-controller_tests/submission_tests
 1/45 Test  #1: chain_tests-controller_tests/submission_tests ....................   Passed    0.03 sec
      Start  2: chain_tests-controller_tests/propose_block
 2/45 Test  #2: chain_tests-controller_tests/propose_block .......................***Failed    0.03 sec
      Start  3: chain_tests-controller_tests/block_irreversibility
 3/45 Test  #3: chain_tests-controller_tests/block_irreversibility ...............   Passed    0.04 sec
      Start  4: chain_tests-controller_tests/fork_heads
 4/45 Test  #4: chain_tests-controller_tests/fork_heads ..........................   Passed    0.05 sec
      Start  5: chain_tests-controller_tests/read_contract_tests
 5/45 Test  #5: chain_tests-controller_tests/read_contract_tests .................   Passed    0.03 sec
      Start  6: chain_tests-controller_tests/transaction_reversion_test
 6/45 Test  #6: chain_tests-controller_tests/transaction_reversion_test ..........   Passed    0.05 sec
      Start  7: chain_tests-controller_tests/receipt_test
 7/45 Test  #7: chain_tests-controller_tests/receipt_test ........................   Passed    0.03 sec
      Start  8: chain_tests-controller_tests/system_call_override_test
 8/45 Test  #8: chain_tests-controller_tests/system_call_override_test ...........   Passed    0.03 sec
      Start  9: chain_tests-controller_tests/invoke_system_call_test
 9/45 Test  #9: chain_tests-controller_tests/invoke_system_call_test .............   Passed    0.03 sec
      Start 10: chain_tests-stack_tests/simple_user_contract
10/45 Test #10: chain_tests-stack_tests/simple_user_contract .....................   Passed    0.03 sec
      Start 11: chain_tests-stack_tests/syscall_from_user
11/45 Test #11: chain_tests-stack_tests/syscall_from_user ........................   Passed    0.03 sec
      Start 12: chain_tests-stack_tests/user_from_user
12/45 Test #12: chain_tests-stack_tests/user_from_user ...........................   Passed    0.03 sec
      Start 13: chain_tests-stack_tests/syscall_override_from_thunk
13/45 Test #13: chain_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.03 sec
      Start 14: chain_tests-stack_tests/syscall_override_from_syscall_override
14/45 Test #14: chain_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.03 sec
      Start 15: chain_tests-stack_tests/system_contract_from_syscall_override
15/45 Test #15: chain_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.04 sec
      Start 16: chain_tests-thunk_tests/get_transaction_field
16/45 Test #16: chain_tests-thunk_tests/get_transaction_field ....................   Passed    0.03 sec
      Start 17: chain_tests-thunk_tests/get_block_field
17/45 Test #17: chain_tests-thunk_tests/get_block_field ..........................   Passed    0.05 sec
      Start 18: chain_tests-thunk_tests/get_operation
18/45 Test #18: chain_tests-thunk_tests/get_operation ............................   Passed    0.04 sec
      Start 19: chain_tests-thunk_tests/db_crud
19/45 Test #19: chain_tests-thunk_tests/db_crud ..................................   Passed    0.03 sec
      Start 20: chain_tests-thunk_tests/db_permissions
20/45 Test #20: chain_tests-thunk_tests/db_permissions ...........................   Passed    0.03 sec
      Start 21: chain_tests-thunk_tests/contract_tests
21/45 Test #21: chain_tests-thunk_tests/contract_tests ...........................   Passed    0.03 sec
      Start 22: chain_tests-thunk_tests/override_tests
22/45 Test #22: chain_tests-thunk_tests/override_tests ...........................   Passed    0.03 sec
      Start 23: chain_tests-thunk_tests/thunk_test
23/45 Test #23: chain_tests-thunk_tests/thunk_test ...............................   Passed    0.03 sec
      Start 24: chain_tests-thunk_tests/system_call_test
24/45 Test #24: chain_tests-thunk_tests/system_call_test .........................   Passed    0.03 sec
      Start 25: chain_tests-thunk_tests/get_head_info_thunk_test
25/45 Test #25: chain_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.03 sec
      Start 26: chain_tests-thunk_tests/hash_thunk_test
26/45 Test #26: chain_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.03 sec
      Start 27: chain_tests-thunk_tests/privileged_calls
27/45 Test #27: chain_tests-thunk_tests/privileged_calls .........................   Passed    0.03 sec
      Start 28: chain_tests-thunk_tests/last_irreversible_block_test
28/45 Test #28: chain_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.03 sec
      Start 29: chain_tests-thunk_tests/stack_tests
29/45 Test #29: chain_tests-thunk_tests/stack_tests ..............................   Passed    0.03 sec
      Start 30: chain_tests-thunk_tests/check_authority
30/45 Test #30: chain_tests-thunk_tests/check_authority ..........................   Passed    0.03 sec
      Start 31: chain_tests-thunk_tests/transaction_nonce_test
31/45 Test #31: chain_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.03 sec
      Start 32: chain_tests-thunk_tests/get_contract_id_test
32/45 Test #32: chain_tests-thunk_tests/get_contract_id_test .....................   Passed    0.03 sec
      Start 33: chain_tests-thunk_tests/token_tests
33/45 Test #33: chain_tests-thunk_tests/token_tests ..............................   Passed    0.03 sec
      Start 34: chain_tests-thunk_tests/call_contract_operation_failure
34/45 Test #34: chain_tests-thunk_tests/call_contract_operation_failure ..........   Passed    0.03 sec
      Start 35: chain_tests-thunk_tests/tick_limit
35/45 Test #35: chain_tests-thunk_tests/tick_limit ...............................   Passed    0.03 sec
      Start 36: chain_tests-thunk_tests/disk_usage
36/45 Test #36: chain_tests-thunk_tests/disk_usage ...............................   Passed    0.03 sec
      Start 37: chain_tests-thunk_tests/transaction_reversion
37/45 Test #37: chain_tests-thunk_tests/transaction_reversion ....................   Passed    0.03 sec
      Start 38: chain_tests-thunk_tests/authorize_tests
38/45 Test #38: chain_tests-thunk_tests/authorize_tests ..........................   Passed    0.04 sec
      Start 39: chain_tests-thunk_tests/get_chain_id
39/45 Test #39: chain_tests-thunk_tests/get_chain_id .............................   Passed    0.03 sec
      Start 40: chain_tests-thunk_tests/system_resources
40/45 Test #40: chain_tests-thunk_tests/system_resources .........................   Passed    0.03 sec
      Start 41: chain_tests-thunk_tests/system_rc
41/45 Test #41: chain_tests-thunk_tests/system_rc ................................   Passed    0.03 sec
      Start 42: chain_tests-thunk_tests/contract_exit
42/45 Test #42: chain_tests-thunk_tests/contract_exit ............................   Passed    0.03 sec
      Start 43: chain_tests-thunk_tests/syscall_override_return
43/45 Test #43: chain_tests-thunk_tests/syscall_override_return ..................   Passed    0.03 sec
      Start 44: chain_tests-thunk_tests/thunk_time
44/45 Test #44: chain_tests-thunk_tests/thunk_time ...............................   Passed    0.26 sec
      Start 45: chain_tests-thunk_tests/null_bytes_written_test
45/45 Test #45: chain_tests-thunk_tests/null_bytes_written_test ..................   Passed    0.03 sec

98% tests passed, 1 tests failed out of 45

Total Test time (real) =   1.74 sec

The following tests FAILED:
          2 - chain_tests-controller_tests/propose_block (Failed)
Errors while running CTest
Output from these tests are in: /home/michael/dev/koinos-chain/build/tests/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

With the fix:
```
❯ ctest
Test project /home/michael/dev/koinos-chain/build/tests
      Start  1: chain_tests-controller_tests/submission_tests
 1/45 Test  #1: chain_tests-controller_tests/submission_tests ....................   Passed    0.03 sec
      Start  2: chain_tests-controller_tests/propose_block
 2/45 Test  #2: chain_tests-controller_tests/propose_block .......................   Passed    0.03 sec
      Start  3: chain_tests-controller_tests/block_irreversibility
 3/45 Test  #3: chain_tests-controller_tests/block_irreversibility ...............   Passed    0.04 sec
      Start  4: chain_tests-controller_tests/fork_heads
 4/45 Test  #4: chain_tests-controller_tests/fork_heads ..........................   Passed    0.05 sec
      Start  5: chain_tests-controller_tests/read_contract_tests
 5/45 Test  #5: chain_tests-controller_tests/read_contract_tests .................   Passed    0.03 sec
      Start  6: chain_tests-controller_tests/transaction_reversion_test
 6/45 Test  #6: chain_tests-controller_tests/transaction_reversion_test ..........   Passed    0.05 sec
      Start  7: chain_tests-controller_tests/receipt_test
 7/45 Test  #7: chain_tests-controller_tests/receipt_test ........................   Passed    0.03 sec
      Start  8: chain_tests-controller_tests/system_call_override_test
 8/45 Test  #8: chain_tests-controller_tests/system_call_override_test ...........   Passed    0.03 sec
      Start  9: chain_tests-controller_tests/invoke_system_call_test
 9/45 Test  #9: chain_tests-controller_tests/invoke_system_call_test .............   Passed    0.03 sec
      Start 10: chain_tests-stack_tests/simple_user_contract
10/45 Test #10: chain_tests-stack_tests/simple_user_contract .....................   Passed    0.03 sec
      Start 11: chain_tests-stack_tests/syscall_from_user
11/45 Test #11: chain_tests-stack_tests/syscall_from_user ........................   Passed    0.03 sec
      Start 12: chain_tests-stack_tests/user_from_user
12/45 Test #12: chain_tests-stack_tests/user_from_user ...........................   Passed    0.03 sec
      Start 13: chain_tests-stack_tests/syscall_override_from_thunk
13/45 Test #13: chain_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.03 sec
      Start 14: chain_tests-stack_tests/syscall_override_from_syscall_override
14/45 Test #14: chain_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.03 sec
      Start 15: chain_tests-stack_tests/system_contract_from_syscall_override
15/45 Test #15: chain_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.03 sec
      Start 16: chain_tests-thunk_tests/get_transaction_field
16/45 Test #16: chain_tests-thunk_tests/get_transaction_field ....................   Passed    0.03 sec
      Start 17: chain_tests-thunk_tests/get_block_field
17/45 Test #17: chain_tests-thunk_tests/get_block_field ..........................   Passed    0.03 sec
      Start 18: chain_tests-thunk_tests/get_operation
18/45 Test #18: chain_tests-thunk_tests/get_operation ............................   Passed    0.03 sec
      Start 19: chain_tests-thunk_tests/db_crud
19/45 Test #19: chain_tests-thunk_tests/db_crud ..................................   Passed    0.03 sec
      Start 20: chain_tests-thunk_tests/db_permissions
20/45 Test #20: chain_tests-thunk_tests/db_permissions ...........................   Passed    0.03 sec
      Start 21: chain_tests-thunk_tests/contract_tests
21/45 Test #21: chain_tests-thunk_tests/contract_tests ...........................   Passed    0.03 sec
      Start 22: chain_tests-thunk_tests/override_tests
22/45 Test #22: chain_tests-thunk_tests/override_tests ...........................   Passed    0.03 sec
      Start 23: chain_tests-thunk_tests/thunk_test
23/45 Test #23: chain_tests-thunk_tests/thunk_test ...............................   Passed    0.03 sec
      Start 24: chain_tests-thunk_tests/system_call_test
24/45 Test #24: chain_tests-thunk_tests/system_call_test .........................   Passed    0.03 sec
      Start 25: chain_tests-thunk_tests/get_head_info_thunk_test
25/45 Test #25: chain_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.03 sec
      Start 26: chain_tests-thunk_tests/hash_thunk_test
26/45 Test #26: chain_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.03 sec
      Start 27: chain_tests-thunk_tests/privileged_calls
27/45 Test #27: chain_tests-thunk_tests/privileged_calls .........................   Passed    0.03 sec
      Start 28: chain_tests-thunk_tests/last_irreversible_block_test
28/45 Test #28: chain_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.03 sec
      Start 29: chain_tests-thunk_tests/stack_tests
29/45 Test #29: chain_tests-thunk_tests/stack_tests ..............................   Passed    0.03 sec
      Start 30: chain_tests-thunk_tests/check_authority
30/45 Test #30: chain_tests-thunk_tests/check_authority ..........................   Passed    0.03 sec
      Start 31: chain_tests-thunk_tests/transaction_nonce_test
31/45 Test #31: chain_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.03 sec
      Start 32: chain_tests-thunk_tests/get_contract_id_test
32/45 Test #32: chain_tests-thunk_tests/get_contract_id_test .....................   Passed    0.03 sec
      Start 33: chain_tests-thunk_tests/token_tests
33/45 Test #33: chain_tests-thunk_tests/token_tests ..............................   Passed    0.03 sec
      Start 34: chain_tests-thunk_tests/call_contract_operation_failure
34/45 Test #34: chain_tests-thunk_tests/call_contract_operation_failure ..........   Passed    0.03 sec
      Start 35: chain_tests-thunk_tests/tick_limit
35/45 Test #35: chain_tests-thunk_tests/tick_limit ...............................   Passed    0.03 sec
      Start 36: chain_tests-thunk_tests/disk_usage
36/45 Test #36: chain_tests-thunk_tests/disk_usage ...............................   Passed    0.03 sec
      Start 37: chain_tests-thunk_tests/transaction_reversion
37/45 Test #37: chain_tests-thunk_tests/transaction_reversion ....................   Passed    0.03 sec
      Start 38: chain_tests-thunk_tests/authorize_tests
38/45 Test #38: chain_tests-thunk_tests/authorize_tests ..........................   Passed    0.04 sec
      Start 39: chain_tests-thunk_tests/get_chain_id
39/45 Test #39: chain_tests-thunk_tests/get_chain_id .............................   Passed    0.03 sec
      Start 40: chain_tests-thunk_tests/system_resources
40/45 Test #40: chain_tests-thunk_tests/system_resources .........................   Passed    0.03 sec
      Start 41: chain_tests-thunk_tests/system_rc
41/45 Test #41: chain_tests-thunk_tests/system_rc ................................   Passed    0.03 sec
      Start 42: chain_tests-thunk_tests/contract_exit
42/45 Test #42: chain_tests-thunk_tests/contract_exit ............................   Passed    0.03 sec
      Start 43: chain_tests-thunk_tests/syscall_override_return
43/45 Test #43: chain_tests-thunk_tests/syscall_override_return ..................   Passed    0.03 sec
      Start 44: chain_tests-thunk_tests/thunk_time
44/45 Test #44: chain_tests-thunk_tests/thunk_time ...............................   Passed    0.25 sec
      Start 45: chain_tests-thunk_tests/null_bytes_written_test
45/45 Test #45: chain_tests-thunk_tests/null_bytes_written_test ..................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 45

Total Test time (real) =   1.67 sec
```