### PR TITLE
Get pending nonce

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/proto"]
+	path = external/proto
+	url = https://github.com/koinos/koinos-proto-cpp.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 as builder
+FROM alpine:3.18 AS builder
 
 RUN apk update && \
     apk add  \
@@ -15,10 +15,10 @@ RUN apk update && \
 ADD . /build
 WORKDIR /build
 
-ENV CC=gcc
-ENV CXX=g++
-ENV CMAKE_C_COMPILER_LAUNCHER=ccache
-ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+ENV CC gcc
+ENV CXX g++
+ENV CMAKE_C_COMPILER_LAUNCHER ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER ccache
 ENV CCACHE_DIR /build/.ccache
 
 RUN git submodule update --init --recursive && \

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -721,9 +721,7 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
                      rpc_failure_exception,
                      "received error from mempool: ${e}",
                      ( "e", resp.error() ) );
-      KOINOS_ASSERT( resp.has_get_pending_nonce(),
-                     rpc_failure_exception,
-                     "received unexpected response from mempool" );
+      KOINOS_ASSERT( resp.has_get_pending_nonce(), rpc_failure_exception, "received unexpected response from mempool" );
       auto mempool_nonce = util::converter::to< chain::value_type >( resp.get_pending_nonce().nonce() );
 
       if( mempool_nonce.has_uint64_value() )

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -624,6 +624,7 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
   std::string payer, payee, nonce;
   uint64_t max_payer_rc;
   uint64_t trx_rc_limit;
+  chain::value_type mempool_nonce;
 
   auto transaction    = request.transaction();
   auto transaction_id = util::to_hex( transaction.id() );
@@ -722,7 +723,7 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
                      "received error from mempool: ${e}",
                      ( "e", resp.error() ) );
       KOINOS_ASSERT( resp.has_get_pending_nonce(), rpc_failure_exception, "received unexpected response from mempool" );
-      auto mempool_nonce = util::converter::to< chain::value_type >( resp.get_pending_nonce().nonce() );
+      mempool_nonce = util::converter::to< chain::value_type >( resp.get_pending_nonce().nonce() );
 
       if( mempool_nonce.has_uint64_value() )
         ctx.set_mempool_nonce( mempool_nonce );

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -660,7 +660,7 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
 
     if( request.broadcast() && _client )
     {
-      rpc::mempool::mempool_request req1, req2;
+      rpc::mempool::mempool_request req1, req2, req3;
       auto* check_pending = req1.mutable_check_pending_account_resources();
 
       check_pending->set_payer( payer );
@@ -672,6 +672,10 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
       check_nonce->set_payee( payee.empty() ? payer : payee );
       check_nonce->set_nonce( nonce );
 
+      auto* pending_nonce = req3.mutable_get_pending_nonce();
+
+      pending_nonce->set_payee( payee.empty() ? payer : payee );
+
       auto future1 = _client->rpc( util::service::mempool,
                                    util::converter::as< std::string >( req1 ),
                                    750ms,
@@ -679,6 +683,11 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
 
       auto future2 = _client->rpc( util::service::mempool,
                                    util::converter::as< std::string >( req2 ),
+                                   750ms,
+                                   mq::retry_policy::none );
+
+      auto future3 = _client->rpc( util::service::mempool,
+                                   util::converter::as< std::string >( req3 ),
                                    750ms,
                                    mq::retry_policy::none );
 
@@ -706,6 +715,19 @@ controller_impl::submit_transaction( const rpc::chain::submit_transaction_reques
                      rpc_failure_exception,
                      "received unexpected response from mempool" );
       KOINOS_ASSERT( resp.check_account_nonce().success(), invalid_nonce_exception, "invalid account nonce" );
+
+      resp.ParseFromString( future3.get() );
+      KOINOS_ASSERT( !resp.has_error(),
+                     rpc_failure_exception,
+                     "received error from mempool: ${e}",
+                     ( "e", resp.error() ) );
+      KOINOS_ASSERT( resp.has_get_pending_nonce(),
+                     rpc_failure_exception,
+                     "received unexpected response from mempool" );
+      auto mempool_nonce = util::converter::to< chain::value_type >( resp.get_pending_nonce().nonce() );
+
+      if( mempool_nonce.has_uint64_value() )
+        ctx.set_mempool_nonce( mempool_nonce );
     }
 
     ctx.resource_meter().set_resource_limit_data( system_call::get_resource_limits( ctx ) );

--- a/src/koinos/chain/execution_context.cpp
+++ b/src/koinos/chain/execution_context.cpp
@@ -93,17 +93,17 @@ void execution_context::clear_operation()
 
 void execution_context::set_mempool_nonce( const chain::value_type& mempool_nonce )
 {
-  _mempool_nonce = std::make_unique< chain::value_type >( mempool_nonce );
+  _mempool_nonce = &mempool_nonce;
 }
 
 const chain::value_type* execution_context::get_mempool_nonce() const
 {
-  return &( *_mempool_nonce );
+  return _mempool_nonce;
 }
 
 void execution_context::clear_mempool_nonce()
 {
-  _mempool_nonce.reset();
+  _mempool_nonce = nullptr;
 }
 
 const std::string& execution_context::get_contract_call_args() const

--- a/src/koinos/chain/execution_context.cpp
+++ b/src/koinos/chain/execution_context.cpp
@@ -91,6 +91,21 @@ void execution_context::clear_operation()
   _op = nullptr;
 }
 
+void execution_context::set_mempool_nonce( const chain::value_type& mempool_nonce )
+{
+  _mempool_nonce = &mempool_nonce;
+}
+
+const chain::value_type* execution_context::get_mempool_nonce() const
+{
+  return _mempool_nonce;
+}
+
+void execution_context::clear_mempool_nonce()
+{
+  _mempool_nonce = nullptr;
+}
+
 const std::string& execution_context::get_contract_call_args() const
 {
   KOINOS_ASSERT( _stack.size() > 1, chain::internal_error_exception, "stack is empty" );

--- a/src/koinos/chain/execution_context.cpp
+++ b/src/koinos/chain/execution_context.cpp
@@ -93,17 +93,17 @@ void execution_context::clear_operation()
 
 void execution_context::set_mempool_nonce( const chain::value_type& mempool_nonce )
 {
-  _mempool_nonce = &mempool_nonce;
+  _mempool_nonce = std::make_unique< chain::value_type >( mempool_nonce );
 }
 
 const chain::value_type* execution_context::get_mempool_nonce() const
 {
-  return _mempool_nonce;
+  return &( *_mempool_nonce );
 }
 
 void execution_context::clear_mempool_nonce()
 {
-  _mempool_nonce = nullptr;
+  _mempool_nonce.reset();
 }
 
 const std::string& execution_context::get_contract_call_args() const

--- a/src/koinos/chain/execution_context.hpp
+++ b/src/koinos/chain/execution_context.hpp
@@ -172,11 +172,10 @@ private:
   abstract_state_node_ptr _current_state_node;
   abstract_state_node_ptr _parent_state_node;
 
-  const protocol::block* _block     = nullptr;
-  const protocol::transaction* _trx = nullptr;
-  const protocol::operation* _op    = nullptr;
-
-  std::unique_ptr< chain::value_type > _mempool_nonce;
+  const protocol::block* _block           = nullptr;
+  const protocol::transaction* _trx       = nullptr;
+  const protocol::operation* _op          = nullptr;
+  const chain::value_type* _mempool_nonce = nullptr;
 
   chain::resource_meter _resource_meter;
   chain::chronicler _chronicler;

--- a/src/koinos/chain/execution_context.hpp
+++ b/src/koinos/chain/execution_context.hpp
@@ -172,10 +172,11 @@ private:
   abstract_state_node_ptr _current_state_node;
   abstract_state_node_ptr _parent_state_node;
 
-  const protocol::block* _block           = nullptr;
-  const protocol::transaction* _trx       = nullptr;
-  const protocol::operation* _op          = nullptr;
-  const chain::value_type* _mempool_nonce = nullptr;
+  const protocol::block* _block     = nullptr;
+  const protocol::transaction* _trx = nullptr;
+  const protocol::operation* _op    = nullptr;
+
+  std::unique_ptr< chain::value_type > _mempool_nonce;
 
   chain::resource_meter _resource_meter;
   chain::chronicler _chronicler;

--- a/src/koinos/chain/execution_context.hpp
+++ b/src/koinos/chain/execution_context.hpp
@@ -12,6 +12,7 @@
 
 #include <koinos/chain/chain.pb.h>
 #include <koinos/chain/system_call_ids.pb.h>
+#include <koinos/chain/value.pb.h>
 #include <koinos/protocol/protocol.pb.h>
 
 #include <deque>
@@ -107,6 +108,10 @@ public:
   const protocol::operation* get_operation() const;
   void clear_operation();
 
+  void set_mempool_nonce( const chain::value_type& );
+  const chain::value_type* get_mempool_nonce() const;
+  void clear_mempool_nonce();
+
   void set_contract_call_args( const std::string& args );
   const std::string& get_contract_call_args() const;
 
@@ -167,9 +172,10 @@ private:
   abstract_state_node_ptr _current_state_node;
   abstract_state_node_ptr _parent_state_node;
 
-  const protocol::block* _block     = nullptr;
-  const protocol::transaction* _trx = nullptr;
-  const protocol::operation* _op    = nullptr;
+  const protocol::block* _block           = nullptr;
+  const protocol::transaction* _trx       = nullptr;
+  const protocol::operation* _op          = nullptr;
+  const chain::value_type* _mempool_nonce = nullptr;
 
   chain::resource_meter _resource_meter;
   chain::chronicler _chronicler;

--- a/src/koinos/chain/system_calls.cpp
+++ b/src/koinos/chain/system_calls.cpp
@@ -483,7 +483,9 @@ THUNK_DEFINE( void, apply_transaction, ( (const protocol::transaction&)trx ) )
                      "invalid transaction nonce - account: ${a}, nonce: ${n}, current nonce: ${c}",
                      ( "a", util::to_base58( nonce_account ) )( "n", util::to_hex( trx.header().nonce() ) )(
                        "c",
-                       util::to_hex( system_call::get_account_nonce( context, nonce_account ) ) ) );
+                       context.get_mempool_nonce()
+                         ? util::to_hex( *context.get_mempool_nonce() )
+                         : util::to_hex( system_call::get_account_nonce( context, nonce_account ) ) ) );
 
       system_call::set_account_nonce( context, nonce_account, trx.header().nonce() );
 
@@ -931,8 +933,10 @@ THUNK_DEFINE( verify_account_nonce_result,
 
   verify_account_nonce_result res;
 
-  if( !context.get_block() && context.get_mempool_nonce() )
+  if( context.get_mempool_nonce() )
+  {
     res.set_value( nonce_value.uint64_value() == context.get_mempool_nonce()->uint64_value() + 1 );
+  }
   else
     res.set_value( nonce_value.uint64_value() == current_nonce_value.uint64_value() + 1 );
 

--- a/src/koinos/chain/system_calls.cpp
+++ b/src/koinos/chain/system_calls.cpp
@@ -930,7 +930,12 @@ THUNK_DEFINE( verify_account_nonce_result,
                  ( "n", util::to_hex( current_nonce_value ) )( "a", util::to_base58( account ) ) );
 
   verify_account_nonce_result res;
-  res.set_value( nonce_value.uint64_value() == current_nonce_value.uint64_value() + 1 );
+
+  if( !context.get_block() && context.get_mempool_nonce() )
+    res.set_value( nonce_value.uint64_value() == context.get_mempool_nonce()->uint64_value() + 1 );
+  else
+    res.set_value( nonce_value.uint64_value() == current_nonce_value.uint64_value() + 1 );
+
   return res;
 }
 


### PR DESCRIPTION
## Brief description

When submitting a transaction to chain, chain first checks for a pending nonce from the mempool and uses it as the account nonce if it exists. This allows a user to queue sequential nonces prior to earlier transactions being included in blocks.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
❯ ./run.sh pending_nonce                               
~/dev/koinos-integration-tests/tests/pending_nonce ~/dev/koinos-integration-tests
[+] Running 6/6
 ✔ Network pending_nonce_default          Created                                                                                                                                                                                                     0.1s 
 ✔ Container pending_nonce-amqp-1         Started                                                                                                                                                                                                     0.2s 
 ✔ Container pending_nonce-chain-1        Started                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-block_store-1  Started                                                                                                                                                                                                     0.5s 
 ✔ Container pending_nonce-jsonrpc-1      Started                                                                                                                                                                                                     0.5s 
 ✔ Container pending_nonce-mempool-1      Started                                                                                                                                                                                                     0.5s 
=== RUN   TestPublishTransaction
    integration.go:699: Waiting 1s for chain to be ready...
    integration.go:699: Waiting 2s for chain to be ready...
    integration.go:699: Waiting 4s for chain to be ready...
--- PASS: TestPublishTransaction (7.04s)
PASS
ok      koinos-integration-tests/tests/pending_nonce    7.056s
[+] Running 6/6
 ✔ Container pending_nonce-jsonrpc-1      Removed                                                                                                                                                                                                     0.2s 
 ✔ Container pending_nonce-mempool-1      Removed                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-block_store-1  Removed                                                                                                                                                                                                     0.1s 
 ✔ Container pending_nonce-chain-1        Removed                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-amqp-1         Removed                                                                                                                                                                                                     1.2s 
 ✔ Network pending_nonce_default          Removed                                                                                                                                                                                                     0.2s 
~/dev/koinos-integration-tests
```