### PR TITLE
#845: Return unknown previous block when the parent node is not final…

### DIFF
--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -323,7 +323,9 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
     return {}; // Block is current LIB
   }
   else
+  {
     KOINOS_ASSERT( parent_node->is_finalized(), unknown_previous_block_exception, "unknown previous block" );
+  }
 
   bool live = block.header().timestamp() > std::chrono::duration_cast< std::chrono::milliseconds >(
                                              ( opts.application_time - live_delta ).time_since_epoch() )

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -322,6 +322,8 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
     KOINOS_ASSERT( block_id == root->id(), unknown_previous_block_exception, "unknown previous block" );
     return {}; // Block is current LIB
   }
+  else
+    KOINOS_ASSERT( parent_node->is_finalized(), unknown_previous_block_exception, "unknown previous block" );
 
   bool live = block.header().timestamp() > std::chrono::duration_cast< std::chrono::milliseconds >(
                                              ( opts.application_time - live_delta ).time_since_epoch() )


### PR DESCRIPTION
…ized

Resolves #845

## Brief description

Returns `unknown_previous_block` error when the parent node is not finalized. The prevents a deadlock when the parent node is trying to finalize and the child node is waiting on the parent node to finalize to create a state node.

Branch is not passing CI because it is not based on `latest` and therefore fails the `pending_nonce` integration test. This is expected. The branch is good otherwise and is running in dev.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
