### PR TITLE
Fix verify-blocks=false state delta replay: preserve tombstones, verify roots, re-execution fallback

### DIFF
--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -104,7 +104,10 @@ public:
   void set_client( std::shared_ptr< mq::client > c );
 
   apply_block_result apply_block( const protocol::block& block, const apply_block_options& opts );
-  void apply_block_delta( const protocol::block&, const protocol::block_receipt&, uint64_t );
+  void apply_block_delta( const protocol::block&,
+                          const protocol::block_receipt&,
+                          uint64_t,
+                          const std::optional< std::string >& expected_root = {} );
 
   rpc::chain::submit_transaction_response submit_transaction( const rpc::chain::submit_transaction_request& );
   rpc::chain::get_head_info_response get_head_info( const rpc::chain::get_head_info_request& );
@@ -633,7 +636,8 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
 
 void controller_impl::apply_block_delta( const protocol::block& block,
                                          const protocol::block_receipt& receipt,
-                                         uint64_t index_to )
+                                         uint64_t index_to,
+                                         const std::optional< std::string >& expected_root )
 {
   uint64_t index_message_interval                  = std::max( 10'000ull, index_to / 1'000ull );
   static constexpr std::chrono::seconds time_delta = std::chrono::seconds( 5 );
@@ -675,6 +679,8 @@ void controller_impl::apply_block_delta( const protocol::block& block,
 
   execution_context ctx( _vm_backend, intent::block_application );
 
+  bool reexecute = false;
+
   try
   {
     ctx.push_frame( stack_frame{ .call_privilege = privilege::kernel_mode } );
@@ -709,51 +715,78 @@ void controller_impl::apply_block_delta( const protocol::block& block,
                      "replayed state delta merkle root does not match block receipt" );
     }
 
-    if( block_height % index_message_interval == 0 )
+    // A recorded receipt delta is not always reproducible: a remove entry may have
+    // been a no-op during execution (excluded from the consensus root but recorded
+    // in the receipt), or the receipt may have lost an entry entirely. When the
+    // caller knows the consensus-signed expectation for this block's root and the
+    // replayed delta does not reproduce it, discard the still-writable node and
+    // rebuild it by fully re-executing the block. Once the node is finalized this
+    // repair is impossible - the head node cannot be discarded.
+    if( expected_root
+        && *expected_root != util::converter::as< std::string >( block_node->pending_merkle_root() ) )
     {
-      auto progress = block_height / static_cast< double >( index_to ) * 100;
-      LOG( info ) << "Indexing chain (" << progress << "%) - Height: " << block_height << ", ID: " << block_id;
-    }
+      LOG( warning ) << "delta_replay_fallback height=" << block_height << " id=" << block_id
+                     << " - replayed delta root does not match the consensus root signed in the"
+                        " next block header; re-executing block through full verification";
 
-    auto lib = system_call::get_last_irreversible_block( ctx );
-
-    try
-    {
-      // We need to finalize our node, checking if it is the new head block, update the cached head block,
-      // and advancing LIB as an atomic action or else we risk _db.get_head(), _cached_head_block, and
-      // LIB desyncing from each other
-      db_lock.reset();
       block_node.reset();
       parent_node.reset();
       ctx.clear_state_node();
+      _db.discard_node( block_id, db_lock );
+      db_lock.reset();
 
-      auto unique_db_lock = _db.get_unique_lock();
-      _db.finalize_node( block_id, unique_db_lock );
-
-      if( block_id == _db.get_head( unique_db_lock )->id() )
-      {
-        std::unique_lock< std::shared_mutex > head_lock( _cached_head_block_mutex );
-        _cached_head_block = std::make_shared< protocol::block >( block );
-      }
-
-      if( lib > _db.get_root( unique_db_lock )->revision() )
-      {
-        auto lib_id = _db.get_node_at_revision( lib, block_id, unique_db_lock )->id();
-        _db.commit_node( lib_id, unique_db_lock );
-      }
-
-      unique_db_lock.reset();
-      db_lock    = _db.get_shared_lock();
-      block_node = _db.get_node( block_id, db_lock );
-      ctx.set_state_node( block_node );
+      // Re-execution happens after this try block so its errors propagate unwrapped
+      reexecute = true;
     }
-    catch( ... )
+
+    if( !reexecute )
     {
-      // If any exception is thrown, reset to the expected local state and then rethrow.
-      db_lock    = _db.get_shared_lock();
-      block_node = _db.get_node( block_id, db_lock );
-      ctx.set_state_node( block_node );
-      throw;
+      if( block_height % index_message_interval == 0 )
+      {
+        auto progress = block_height / static_cast< double >( index_to ) * 100;
+        LOG( info ) << "Indexing chain (" << progress << "%) - Height: " << block_height << ", ID: " << block_id;
+      }
+
+      auto lib = system_call::get_last_irreversible_block( ctx );
+
+      try
+      {
+        // We need to finalize our node, checking if it is the new head block, update the cached head block,
+        // and advancing LIB as an atomic action or else we risk _db.get_head(), _cached_head_block, and
+        // LIB desyncing from each other
+        db_lock.reset();
+        block_node.reset();
+        parent_node.reset();
+        ctx.clear_state_node();
+
+        auto unique_db_lock = _db.get_unique_lock();
+        _db.finalize_node( block_id, unique_db_lock );
+
+        if( block_id == _db.get_head( unique_db_lock )->id() )
+        {
+          std::unique_lock< std::shared_mutex > head_lock( _cached_head_block_mutex );
+          _cached_head_block = std::make_shared< protocol::block >( block );
+        }
+
+        if( lib > _db.get_root( unique_db_lock )->revision() )
+        {
+          auto lib_id = _db.get_node_at_revision( lib, block_id, unique_db_lock )->id();
+          _db.commit_node( lib_id, unique_db_lock );
+        }
+
+        unique_db_lock.reset();
+        db_lock    = _db.get_shared_lock();
+        block_node = _db.get_node( block_id, db_lock );
+        ctx.set_state_node( block_node );
+      }
+      catch( ... )
+      {
+        // If any exception is thrown, reset to the expected local state and then rethrow.
+        db_lock    = _db.get_shared_lock();
+        block_node = _db.get_node( block_id, db_lock );
+        ctx.set_state_node( block_node );
+        throw;
+      }
     }
 
     // It is NOT safe to use block_node after this point without checking it against null
@@ -798,6 +831,22 @@ void controller_impl::apply_block_delta( const protocol::block& block,
     }
 
     throw;
+  }
+
+  if( reexecute )
+  {
+    apply_block( block, apply_block_options{ index_to, std::chrono::system_clock::now(), false } );
+
+    // No retry loop: if full re-execution cannot reproduce the consensus root either,
+    // the divergence is genuine corruption and the sync must halt here.
+    auto reexec_lock     = _db.get_shared_lock();
+    auto reexecuted_node = _db.get_node( block_id, reexec_lock );
+    KOINOS_ASSERT( reexecuted_node,
+                   block_state_error_exception,
+                   "re-executed block node is missing after fallback" );
+    KOINOS_ASSERT( *expected_root == util::converter::as< std::string >( reexecuted_node->merkle_root() ),
+                   state_merkle_mismatch_exception,
+                   "re-executed block does not reproduce the consensus state merkle root" );
   }
 }
 
@@ -1327,6 +1376,14 @@ void controller::apply_block_delta( const protocol::block& block,
                                     uint64_t index_to )
 {
   _my->apply_block_delta( block, receipt, index_to );
+}
+
+void controller::apply_block_delta_checked( const protocol::block& block,
+                                            const protocol::block_receipt& receipt,
+                                            const std::string& expected_root,
+                                            uint64_t index_to )
+{
+  _my->apply_block_delta( block, receipt, index_to, expected_root );
 }
 
 rpc::chain::propose_block_response controller::propose_block( const rpc::chain::propose_block_request& request,

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -684,7 +684,11 @@ void controller_impl::apply_block_delta( const protocol::block& block,
       if( delta_entry.has_value() )
         block_node->put_object( object_space, delta_entry.key(), &delta_entry.value() );
       else
-        block_node->remove_object( object_space, delta_entry.key() );
+        // A remove entry in a serialized receipt is a committed part of the historical
+        // block delta. It must be preserved as a tombstone even when the key is absent
+        // from the parent state (key created and removed within the same block),
+        // otherwise the replayed state delta merkle root diverges from the receipt root.
+        block_node->remove_object_preserve_tombstone( object_space, delta_entry.key() );
     }
 
     if( block_height % index_message_interval == 0 )

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -392,10 +392,15 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
                    timestamp_out_of_bounds_exception,
                    "block timestamp is too old" );
 
-    KOINOS_ASSERT( block.header().previous_state_merkle_root()
-                     == util::converter::as< std::string >( parent_node->merkle_root() ),
-                   state_merkle_mismatch_exception,
-                   "block previous state merkle mismatch" );
+    {
+      auto parent_root = util::converter::as< std::string >( parent_node->merkle_root() );
+      KOINOS_ASSERT( block.header().previous_state_merkle_root() == parent_root
+                       || acceptable_rectified_previous_root( block.header().previous(),
+                                                              parent_root,
+                                                              block.header().previous_state_merkle_root() ),
+                     state_merkle_mismatch_exception,
+                     "block previous state merkle mismatch" );
+    }
 
     ctx.push_frame( stack_frame{ .call_privilege = privilege::kernel_mode } );
 
@@ -670,10 +675,15 @@ bool controller_impl::apply_block_delta( const protocol::block& block,
   // The header's previous state merkle root is the consensus-signed root of the
   // parent block's delta. Replay must verify it like full execution does, or a
   // divergence surfaces far from the block that caused it.
-  KOINOS_ASSERT( block.header().previous_state_merkle_root()
-                   == util::converter::as< std::string >( parent_node->merkle_root() ),
-                 state_merkle_mismatch_exception,
-                 "block previous state merkle mismatch" );
+  {
+    auto parent_root = util::converter::as< std::string >( parent_node->merkle_root() );
+    KOINOS_ASSERT( block.header().previous_state_merkle_root() == parent_root
+                     || acceptable_rectified_previous_root( block.header().previous(),
+                                                            parent_root,
+                                                            block.header().previous_state_merkle_root() ),
+                   state_merkle_mismatch_exception,
+                   "block previous state merkle mismatch" );
+  }
 
   block_node = _db.create_writable_node( parent_id, block_id, block.header(), db_lock );
 
@@ -715,15 +725,20 @@ bool controller_impl::apply_block_delta( const protocol::block& block,
                      "replayed state delta merkle root does not match block receipt" );
     }
 
-    // A recorded receipt delta is not always reproducible: a remove entry may have
-    // been a no-op during execution (excluded from the consensus root but recorded
-    // in the receipt), or the receipt may have lost an entry entirely. When the
+    // A recorded receipt delta is not always reproducible: the receipt may have
+    // lost entries (see maybe_rectify_state), or the signed root itself may be a
+    // known consensus scar (see acceptable_rectified_previous_root). When the
     // caller knows the consensus-signed expectation for this block's root and the
-    // replayed delta does not reproduce it, discard the still-writable node and
-    // rebuild it by fully re-executing the block. Once the node is finalized this
-    // repair is impossible - the head node cannot be discarded.
+    // replayed delta does not reproduce it - directly or through a recorded
+    // rectification - discard the still-writable node and rebuild it by fully
+    // re-executing the block. Once the node is finalized this repair is
+    // impossible - the head node cannot be discarded.
     if( expected_root
-        && *expected_root != util::converter::as< std::string >( block_node->pending_merkle_root() ) )
+        && *expected_root != util::converter::as< std::string >( block_node->pending_merkle_root() )
+        && !acceptable_rectified_previous_root(
+          block.id(),
+          util::converter::as< std::string >( block_node->pending_merkle_root() ),
+          *expected_root ) )
     {
       LOG( warning ) << "delta_replay_fallback height=" << block_height << " id=" << block_id
                      << " - replayed delta root does not match the consensus root signed in the"

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -663,6 +663,14 @@ void controller_impl::apply_block_delta( const protocol::block& block,
     return; // Block is current LIB
   }
 
+  // The header's previous state merkle root is the consensus-signed root of the
+  // parent block's delta. Replay must verify it like full execution does, or a
+  // divergence surfaces far from the block that caused it.
+  KOINOS_ASSERT( block.header().previous_state_merkle_root()
+                   == util::converter::as< std::string >( parent_node->merkle_root() ),
+                 state_merkle_mismatch_exception,
+                 "block previous state merkle mismatch" );
+
   block_node = _db.create_writable_node( parent_id, block_id, block.header(), db_lock );
 
   execution_context ctx( _vm_backend, intent::block_application );
@@ -689,6 +697,16 @@ void controller_impl::apply_block_delta( const protocol::block& block,
         // from the parent state (key created and removed within the same block),
         // otherwise the replayed state delta merkle root diverges from the receipt root.
         block_node->remove_object_preserve_tombstone( object_space, delta_entry.key() );
+    }
+
+    // All mainnet receipts to date carry an empty state merkle root, but if one is
+    // present the replayed delta must reproduce it exactly.
+    if( receipt.state_merkle_root().size() )
+    {
+      KOINOS_ASSERT( receipt.state_merkle_root()
+                       == util::converter::as< std::string >( block_node->pending_merkle_root() ),
+                     state_merkle_mismatch_exception,
+                     "replayed state delta merkle root does not match block receipt" );
     }
 
     if( block_height % index_message_interval == 0 )

--- a/src/koinos/chain/controller.cpp
+++ b/src/koinos/chain/controller.cpp
@@ -104,7 +104,7 @@ public:
   void set_client( std::shared_ptr< mq::client > c );
 
   apply_block_result apply_block( const protocol::block& block, const apply_block_options& opts );
-  void apply_block_delta( const protocol::block&,
+  bool apply_block_delta( const protocol::block&,
                           const protocol::block_receipt&,
                           uint64_t,
                           const std::optional< std::string >& expected_root = {} );
@@ -634,7 +634,7 @@ apply_block_result controller_impl::apply_block( const protocol::block& block, c
   return res;
 }
 
-void controller_impl::apply_block_delta( const protocol::block& block,
+bool controller_impl::apply_block_delta( const protocol::block& block,
                                          const protocol::block_receipt& receipt,
                                          uint64_t index_to,
                                          const std::optional< std::string >& expected_root )
@@ -664,7 +664,7 @@ void controller_impl::apply_block_delta( const protocol::block& block,
                    pre_irreversibility_block_exception,
                    "block is prior to irreversibility" );
     KOINOS_ASSERT( block_id == root->id(), unknown_previous_block_exception, "unknown previous block" );
-    return; // Block is current LIB
+    return false; // Block is current LIB
   }
 
   // The header's previous state merkle root is the consensus-signed root of the
@@ -848,6 +848,8 @@ void controller_impl::apply_block_delta( const protocol::block& block,
                    state_merkle_mismatch_exception,
                    "re-executed block does not reproduce the consensus state merkle root" );
   }
+
+  return reexecute;
 }
 
 rpc::chain::submit_transaction_response
@@ -1378,12 +1380,12 @@ void controller::apply_block_delta( const protocol::block& block,
   _my->apply_block_delta( block, receipt, index_to );
 }
 
-void controller::apply_block_delta_checked( const protocol::block& block,
+bool controller::apply_block_delta_checked( const protocol::block& block,
                                             const protocol::block_receipt& receipt,
                                             const std::string& expected_root,
                                             uint64_t index_to )
 {
-  _my->apply_block_delta( block, receipt, index_to, expected_root );
+  return _my->apply_block_delta( block, receipt, index_to, expected_root );
 }
 
 rpc::chain::propose_block_response controller::propose_block( const rpc::chain::propose_block_request& request,

--- a/src/koinos/chain/controller.hpp
+++ b/src/koinos/chain/controller.hpp
@@ -43,7 +43,9 @@ public:
                 uint64_t index_to                         = 0,
                 std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
   void apply_block_delta( const protocol::block&, const protocol::block_receipt&, uint64_t index_to );
-  void apply_block_delta_checked( const protocol::block&,
+  // Returns true if the delta could not reproduce expected_root and the block
+  // was rebuilt through full re-execution
+  bool apply_block_delta_checked( const protocol::block&,
                                   const protocol::block_receipt&,
                                   const std::string& expected_root,
                                   uint64_t index_to );

--- a/src/koinos/chain/controller.hpp
+++ b/src/koinos/chain/controller.hpp
@@ -43,6 +43,10 @@ public:
                 uint64_t index_to                         = 0,
                 std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
   void apply_block_delta( const protocol::block&, const protocol::block_receipt&, uint64_t index_to );
+  void apply_block_delta_checked( const protocol::block&,
+                                  const protocol::block_receipt&,
+                                  const std::string& expected_root,
+                                  uint64_t index_to );
   rpc::chain::propose_block_response
   propose_block( const rpc::chain::propose_block_request&,
                  uint64_t index_to                         = 0,

--- a/src/koinos/chain/indexer.cpp
+++ b/src/koinos/chain/indexer.cpp
@@ -219,11 +219,22 @@ void indexer::process_block()
 
     if( _request_processing_complete && _block_queue.empty() )
     {
+      if( _pending_item )
+      {
+        // The final item is the target head. It has no successor header to check
+        // against, so it is applied unchecked; its root is cross-checked by the
+        // first live block, as before.
+        _controller.apply_block_delta( _pending_item->block(), _pending_item->receipt(), _target_head.height() );
+        _pending_item.reset();
+      }
+
       const auto new_head_info                       = _controller.get_head_info();
       const std::chrono::duration< double > duration = std::chrono::system_clock::now() - _start_time;
       LOG( info ) << "Finished indexing "
                   << new_head_info.head_topology().height() - _start_head_info.head_topology().height()
                   << " blocks, took " << duration.count() << " seconds";
+      if( !_verify_blocks )
+        LOG( info ) << "Delta replay re-execution fallbacks: " << _fallback_count;
       _complete->set_value( true );
       _complete.reset();
       return;
@@ -238,7 +249,20 @@ void indexer::process_block()
       _controller.submit_block( submit_block, _target_head.height() );
     }
     else
-      _controller.apply_block_delta( block_item.block(), block_item.receipt(), _target_head.height() );
+    {
+      // One-block lookahead: the newly pulled item's header carries the
+      // consensus-signed merkle root of the pending block's delta
+      if( _pending_item )
+      {
+        if( _controller.apply_block_delta_checked( _pending_item->block(),
+                                                   _pending_item->receipt(),
+                                                   block_item.block().header().previous_state_merkle_root(),
+                                                   _target_head.height() ) )
+          _fallback_count++;
+      }
+
+      _pending_item = std::move( block_item );
+    }
 
     boost::asio::post( std::bind( &indexer::process_block, this ) );
   }

--- a/src/koinos/chain/indexer.hpp
+++ b/src/koinos/chain/indexer.hpp
@@ -45,6 +45,11 @@ private:
 
   boost::concurrent::sync_bounded_queue< block_store::block_item > _block_queue;
 
+  // One-block lookahead for delta replay: block H is applied when H+1 is pulled,
+  // so H+1's header supplies the consensus expectation for H's delta root
+  std::optional< block_store::block_item > _pending_item;
+  uint64_t _fallback_count = 0;
+
   block_topology _target_head;
   rpc::chain::get_head_info_response _start_head_info;
   const std::chrono::time_point< std::chrono::system_clock > _start_time = std::chrono::system_clock::now();

--- a/src/koinos/chain/rectify.cpp
+++ b/src/koinos/chain/rectify.cpp
@@ -117,4 +117,38 @@ void maybe_rectify_state( execution_context& ctx, const protocol::block& block, 
   }
 }
 
+bool acceptable_rectified_previous_root( const std::string& parent_block_id,
+                                         const std::string& computed_parent_root,
+                                         const std::string& claimed_previous_root )
+{
+  // Mainnet block 32,789,377 - the last block before the January 2026 halt.
+  //
+  // Its honest state delta contains 12 entries, including a remove of the
+  // Koinos Fund vote ordering key "02076430234253060999996". The neighbouring
+  // blocks of the same shape (32,789,375 and 32,789,376) prove the network
+  // counted such removes: their signed roots match only when all 12 entries
+  // are preserved. When production resumed after the halt, the recovering
+  // node computed this block's delta root with the pre-fix replay semantics,
+  // which dropped that tombstone, and the resulting 11-entry root was signed
+  // into block 32,789,378's previous_state_merkle_root. The signed value is
+  // therefore a permanent consensus scar: no honest application of the block
+  // can reproduce it.
+  //
+  // Accept the historically signed root, but only when the locally computed
+  // root is the honest one - any other combination is genuine corruption.
+  if( parent_block_id
+      == util::from_hex< std::string >(
+        "0x1220a97d7b0567ad55e3b04446a2bef447335cfd676668b069544b04a4719146d586" ) )
+  {
+    return computed_parent_root
+             == util::from_hex< std::string >(
+               "0x12203a22d59290a838dd49c87f57fe80319636950948f6b9aaf02287c03bb36e5f68" )
+        && claimed_previous_root
+             == util::from_hex< std::string >(
+               "0x12209948b54dee01acd8528cf15dec02366b76e7739aedaf4487859bf6d0d182d690" );
+  }
+
+  return false;
+}
+
 } // namespace koinos::chain

--- a/src/koinos/chain/rectify.hpp
+++ b/src/koinos/chain/rectify.hpp
@@ -8,4 +8,18 @@ namespace koinos::chain {
 
 void maybe_rectify_state( execution_context&, const protocol::block&, protocol::block_receipt& );
 
+/**
+ * Returns true when a block header's previous_state_merkle_root is a known
+ * historically-signed rectified value for the given parent block.
+ *
+ * Covers consensus scars where the root signed into the chain differs from the
+ * root an honest application of the parent block produces. The parent block's
+ * state and receipt remain the honest ones; only the comparison against the
+ * signed header value is relaxed, and only for the exact (parent id, computed
+ * root, claimed root) triple recorded here.
+ */
+bool acceptable_rectified_previous_root( const std::string& parent_block_id,
+                                         const std::string& computed_parent_root,
+                                         const std::string& claimed_previous_root );
+
 } // namespace koinos::chain

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -1953,4 +1953,121 @@ BOOST_AUTO_TEST_CASE( apply_block_delta_kfs_tombstone_test )
   }
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }
+
+BOOST_AUTO_TEST_CASE( apply_block_delta_checked_test )
+{
+  try
+  {
+    using namespace koinos;
+
+    BOOST_TEST_MESSAGE( "Test checked delta replay: clean path, re-execution fallback, and unrecoverable mismatch" );
+
+    // Execute real signed blocks on the fixture controller to obtain genuine
+    // receipts, then replay them on second controllers opened with the same
+    // genesis data, as the indexer would when syncing from a block store.
+
+    auto make_replay_controller = [ & ]( const std::filesystem::path& dir )
+    {
+      std::filesystem::create_directory( dir );
+      auto c = std::make_unique< chain::controller >( 10'000'000, 64'000 );
+      c->open( dir, _genesis_data, chain::fork_resolution_algorithm::fifo, false );
+      return c;
+    };
+
+    auto duration = std::chrono::system_clock::now().time_since_epoch();
+
+    rpc::chain::submit_block_request block_req_1;
+    block_req_1.mutable_block()->mutable_header()->set_height( 1 );
+    block_req_1.mutable_block()->mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() );
+    block_req_1.mutable_block()->mutable_header()->set_previous(
+      util::converter::as< std::string >( crypto::multihash::zero( crypto::multicodec::sha2_256 ) ) );
+    block_req_1.mutable_block()->mutable_header()->set_previous_state_merkle_root(
+      _controller.get_head_info().head_state_merkle_root() );
+    set_block_merkle_roots( *block_req_1.mutable_block(), crypto::multicodec::sha2_256 );
+    block_req_1.mutable_block()->set_id( util::converter::as< std::string >(
+      koinos::crypto::hash( crypto::multicodec::sha2_256, block_req_1.block().header() ) ) );
+    sign_block( *block_req_1.mutable_block(), _block_signing_private_key );
+
+    auto receipt_1 = _controller.submit_block( block_req_1 ).receipt();
+    BOOST_REQUIRE( receipt_1.state_merkle_root().size() );
+
+    rpc::chain::submit_block_request block_req_2;
+    block_req_2.mutable_block()->mutable_header()->set_height( 2 );
+    block_req_2.mutable_block()->mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() + 3'000 );
+    block_req_2.mutable_block()->mutable_header()->set_previous( block_req_1.block().id() );
+    block_req_2.mutable_block()->mutable_header()->set_previous_state_merkle_root(
+      _controller.get_head_info().head_state_merkle_root() );
+    set_block_merkle_roots( *block_req_2.mutable_block(), crypto::multicodec::sha2_256 );
+    block_req_2.mutable_block()->set_id( util::converter::as< std::string >(
+      koinos::crypto::hash( crypto::multicodec::sha2_256, block_req_2.block().header() ) ) );
+    sign_block( *block_req_2.mutable_block(), _block_signing_private_key );
+
+    auto receipt_2 = _controller.submit_block( block_req_2 ).receipt();
+
+    // Mainnet receipts carry an empty state merkle root; the replayed receipts
+    // below mimic that so the checked-apply expectation is the only root check.
+    auto tamper = [ & ]( protocol::block_receipt receipt )
+    {
+      receipt.clear_state_merkle_root();
+      auto* extra_remove = receipt.add_state_delta_entries();
+      extra_remove->mutable_object_space()->set_system( true );
+      extra_remove->set_key( "checked-apply-extra-remove" );
+      return receipt;
+    };
+
+    BOOST_TEST_MESSAGE( "Checked apply with the correct expected root behaves like the unchecked apply" );
+
+    auto clean_dir        = std::filesystem::temp_directory_path() / boost::filesystem::unique_path().string();
+    auto clean_controller = make_replay_controller( clean_dir );
+
+    BOOST_CHECK_EQUAL( false,
+                       clean_controller->apply_block_delta_checked( block_req_1.block(),
+                                                                    receipt_1,
+                                                                    receipt_1.state_merkle_root(),
+                                                                    2 ) );
+    BOOST_CHECK_EQUAL( util::to_hex( block_req_1.block().id() ),
+                       util::to_hex( clean_controller->get_head_info().head_topology().id() ) );
+    BOOST_CHECK_EQUAL( util::to_hex( receipt_1.state_merkle_root() ),
+                       util::to_hex( clean_controller->get_head_info().head_state_merkle_root() ) );
+
+    BOOST_TEST_MESSAGE( "An irreproducible delta triggers re-execution that rebuilds the consensus root" );
+
+    // The tampered receipt carries a remove entry consensus never included
+    // (the anomaly-1 shape), so no replay of its entries can reproduce the
+    // expected root and the block must be rebuilt by full re-execution. The
+    // parent block 1 is already head, pinning the design constraint that the
+    // fallback only ever discards the still-writable node, never the head.
+    BOOST_CHECK_EQUAL( true,
+                       clean_controller->apply_block_delta_checked( block_req_2.block(),
+                                                                    tamper( receipt_2 ),
+                                                                    receipt_2.state_merkle_root(),
+                                                                    2 ) );
+    BOOST_CHECK_EQUAL( util::to_hex( block_req_2.block().id() ),
+                       util::to_hex( clean_controller->get_head_info().head_topology().id() ) );
+    BOOST_CHECK_EQUAL( util::to_hex( receipt_2.state_merkle_root() ),
+                       util::to_hex( clean_controller->get_head_info().head_state_merkle_root() ) );
+
+    BOOST_TEST_MESSAGE( "An expectation nothing can reproduce halts the sync instead of being masked" );
+
+    auto halt_dir        = std::filesystem::temp_directory_path() / boost::filesystem::unique_path().string();
+    auto halt_controller = make_replay_controller( halt_dir );
+
+    auto unreachable_root = util::converter::as< std::string >(
+      crypto::hash( crypto::multicodec::sha2_256, "not a reachable state merkle root"s ) );
+
+    BOOST_CHECK_THROW( halt_controller->apply_block_delta_checked( block_req_1.block(),
+                                                                   tamper( receipt_1 ),
+                                                                   unreachable_root,
+                                                                   2 ),
+                       chain::state_merkle_mismatch_exception );
+
+    clean_controller.reset();
+    halt_controller.reset();
+    std::filesystem::remove_all( clean_dir );
+    std::filesystem::remove_all( halt_dir );
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -10,6 +10,7 @@
 #include <koinos/chain/state.hpp>
 #include <koinos/chain/system_calls.hpp>
 #include <koinos/crypto/elliptic.hpp>
+#include <koinos/crypto/merkle_tree.hpp>
 #include <koinos/crypto/multihash.hpp>
 #include <koinos/util/base58.hpp>
 #include <koinos/util/hex.hpp>
@@ -21,7 +22,10 @@
 #include <koinos/chain/system_calls.pb.h>
 #include <koinos/contracts/token/token.pb.h>
 
+#include <algorithm>
 #include <chrono>
+#include <utility>
+#include <vector>
 #include <filesystem>
 #include <sstream>
 
@@ -1684,6 +1688,268 @@ BOOST_AUTO_TEST_CASE( invoke_system_call_test )
     {
       BOOST_FAIL( "An unexpected exception was thrown" );
     }
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
+
+BOOST_AUTO_TEST_CASE( apply_block_delta_tombstone_test )
+{
+  try
+  {
+    using namespace koinos;
+
+    BOOST_TEST_MESSAGE( "Test that apply_block_delta preserves receipt remove entries as tombstones" );
+
+    // A block receipt is a compacted net delta. When a key is created and removed within
+    // the same block, the receipt contains a remove entry for a key that is absent from
+    // the parent state. Replaying that entry must preserve the tombstone, otherwise the
+    // replayed state delta merkle root diverges from the network and the next block fails
+    // with a previous state merkle mismatch.
+
+    const auto space = chain::state::space::metadata();
+
+    protocol::object_space delta_space;
+    delta_space.set_system( space.system() );
+    delta_space.set_zone( space.zone() );
+    delta_space.set_id( space.id() );
+
+    auto database_key_string = [ & ]( const std::string& key )
+    {
+      chain::database_key db_key;
+      *db_key.mutable_space() = space;
+      db_key.set_key( key );
+      return util::converter::as< std::string >( db_key );
+    };
+
+    auto delta_merkle_root = [ & ]( std::vector< std::pair< std::string, std::string > > entries )
+    {
+      std::sort( entries.begin(),
+                 entries.end(),
+                 []( const auto& lhs, const auto& rhs )
+                 {
+                   return lhs.first < rhs.first;
+                 } );
+
+      std::vector< std::string > merkle_leafs;
+      merkle_leafs.reserve( entries.size() * 2 );
+      for( const auto& [ key, value ]: entries )
+      {
+        merkle_leafs.push_back( key );
+        merkle_leafs.push_back( value );
+      }
+
+      return util::converter::as< std::string >(
+        crypto::merkle_tree< std::string >( crypto::multicodec::sha2_256, merkle_leafs ).root()->hash() );
+    };
+
+    const std::string old_key       = "delta-old-key";
+    const std::string old_value     = "delta-old-value";
+    const std::string transient_key = "delta-transient-key";
+    const std::string final_key     = "delta-final-key";
+    const std::string final_value   = "delta-final-value";
+
+    auto duration = std::chrono::system_clock::now().time_since_epoch();
+
+    // Block 1 puts the old key so that block 2 can legitimately remove it
+    protocol::block block_1;
+    block_1.mutable_header()->set_height( 1 );
+    block_1.mutable_header()->set_previous(
+      util::converter::as< std::string >( crypto::multihash::zero( crypto::multicodec::sha2_256 ) ) );
+    block_1.mutable_header()->set_previous_state_merkle_root(
+      _controller.get_head_info().head_state_merkle_root() );
+    block_1.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() );
+    block_1.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_1.header() ) ) );
+
+    protocol::block_receipt receipt_1;
+    auto* put_entry                   = receipt_1.add_state_delta_entries();
+    *put_entry->mutable_object_space() = delta_space;
+    put_entry->set_key( old_key );
+    put_entry->set_value( old_value );
+
+    _controller.apply_block_delta( block_1, receipt_1, 2 );
+
+    auto block_1_root = _controller.get_head_info().head_state_merkle_root();
+    BOOST_REQUIRE_EQUAL( util::to_hex( delta_merkle_root( {
+                           { database_key_string( old_key ), old_value }
+    } ) ),
+                         util::to_hex( block_1_root ) );
+
+    // Block 2 carries the compacted delta of: remove old, put transient, remove
+    // transient, put final. The serialized receipt therefore contains a remove
+    // entry for the transient key, which is absent from the parent state.
+    protocol::block block_2;
+    block_2.mutable_header()->set_height( 2 );
+    block_2.mutable_header()->set_previous( block_1.id() );
+    block_2.mutable_header()->set_previous_state_merkle_root( block_1_root );
+    block_2.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() + 3'000 );
+    block_2.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_2.header() ) ) );
+
+    protocol::block_receipt receipt_2;
+
+    auto* remove_old_entry                    = receipt_2.add_state_delta_entries();
+    *remove_old_entry->mutable_object_space() = delta_space;
+    remove_old_entry->set_key( old_key );
+
+    auto* remove_transient_entry                    = receipt_2.add_state_delta_entries();
+    *remove_transient_entry->mutable_object_space() = delta_space;
+    remove_transient_entry->set_key( transient_key );
+
+    auto* put_final_entry                    = receipt_2.add_state_delta_entries();
+    *put_final_entry->mutable_object_space() = delta_space;
+    put_final_entry->set_key( final_key );
+    put_final_entry->set_value( final_value );
+
+    _controller.apply_block_delta( block_2, receipt_2, 2 );
+
+    // The replayed delta merkle root must include the absent-key tombstone. Without
+    // preserved tombstone semantics the transient remove entry is dropped and this
+    // root no longer matches the network, so the next block would be rejected with
+    // "block previous state merkle mismatch".
+    BOOST_REQUIRE_EQUAL( util::to_hex( delta_merkle_root( {
+                           { database_key_string( old_key ), std::string() },
+                           { database_key_string( transient_key ), std::string() },
+                           { database_key_string( final_key ), final_value }
+    } ) ),
+                         util::to_hex( _controller.get_head_info().head_state_merkle_root() ) );
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
+
+BOOST_AUTO_TEST_CASE( apply_block_delta_kfs_tombstone_test )
+{
+  try
+  {
+    using namespace koinos;
+
+    BOOST_TEST_MESSAGE( "Test that apply_block_delta preserves tombstones in the Koinos Fund vote ordering flow" );
+
+    // The historical mainnet trigger: the Koinos Fund contract keeps a vote-ordering
+    // index keyed by total votes. A vote update within a block moves a project entry
+    // through an intermediate ordering key that is created and removed in the same
+    // block (vhp burn -> vote update -> koin mint -> vote update again). The compacted
+    // receipt therefore contains a remove entry for an ordering key that is absent
+    // from the parent state. This reproduces the failure shape of causal block
+    // 32789377 ("11 delta entries instead of 12").
+
+    const std::string kfs_contract_id = "1A5BmMqV5jN5zBrdkhQumAfDZBzXLPBeN9";
+
+    chain::object_space space;
+    space.set_system( true );
+    space.set_zone( util::from_base58< std::string >( kfs_contract_id ) );
+    space.set_id( 2 );
+
+    protocol::object_space delta_space;
+    delta_space.set_system( space.system() );
+    delta_space.set_zone( space.zone() );
+    delta_space.set_id( space.id() );
+
+    auto database_key_string = [ & ]( const std::string& key )
+    {
+      chain::database_key db_key;
+      *db_key.mutable_space() = space;
+      db_key.set_key( key );
+      return util::converter::as< std::string >( db_key );
+    };
+
+    auto delta_merkle_root = [ & ]( std::vector< std::pair< std::string, std::string > > entries )
+    {
+      std::sort( entries.begin(),
+                 entries.end(),
+                 []( const auto& lhs, const auto& rhs )
+                 {
+                   return lhs.first < rhs.first;
+                 } );
+
+      std::vector< std::string > merkle_leafs;
+      merkle_leafs.reserve( entries.size() * 2 );
+      for( const auto& [ key, value ]: entries )
+      {
+        merkle_leafs.push_back( key );
+        merkle_leafs.push_back( value );
+      }
+
+      return util::converter::as< std::string >(
+        crypto::merkle_tree< std::string >( crypto::multicodec::sha2_256, merkle_leafs ).root()->hash() );
+    };
+
+    const std::string old_order_key       = "active/by_votes/0000000100/project/0000000007";
+    const std::string old_order_value     = "fund.project id=7 status=active total_votes=100";
+    const std::string transient_order_key = "active/by_votes/0000000175/project/0000000007";
+    const std::string final_order_key     = "active/by_votes/0000000250/project/0000000007";
+    const std::string final_order_value   = "fund.project id=7 status=active total_votes=250";
+
+    auto duration = std::chrono::system_clock::now().time_since_epoch();
+
+    // Block 1 establishes the current vote-ordering entry in the parent state
+    protocol::block block_1;
+    block_1.mutable_header()->set_height( 1 );
+    block_1.mutable_header()->set_previous(
+      util::converter::as< std::string >( crypto::multihash::zero( crypto::multicodec::sha2_256 ) ) );
+    block_1.mutable_header()->set_previous_state_merkle_root(
+      _controller.get_head_info().head_state_merkle_root() );
+    block_1.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() );
+    block_1.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_1.header() ) ) );
+
+    protocol::block_receipt receipt_1;
+    auto* put_entry                    = receipt_1.add_state_delta_entries();
+    *put_entry->mutable_object_space() = delta_space;
+    put_entry->set_key( old_order_key );
+    put_entry->set_value( old_order_value );
+
+    _controller.apply_block_delta( block_1, receipt_1, 2 );
+
+    auto block_1_root = _controller.get_head_info().head_state_merkle_root();
+    BOOST_REQUIRE_EQUAL( util::to_hex( delta_merkle_root( {
+                           { database_key_string( old_order_key ), old_order_value }
+    } ) ),
+                         util::to_hex( block_1_root ) );
+
+    // Block 2 carries the compacted delta of the vote update: remove the old
+    // ordering key, put and remove the intermediate ordering key, put the final
+    // ordering key. The serialized receipt contains a remove entry for the
+    // intermediate key, which is absent from the parent state.
+    protocol::block block_2;
+    block_2.mutable_header()->set_height( 2 );
+    block_2.mutable_header()->set_previous( block_1.id() );
+    block_2.mutable_header()->set_previous_state_merkle_root( block_1_root );
+    block_2.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() + 3'000 );
+    block_2.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_2.header() ) ) );
+
+    protocol::block_receipt receipt_2;
+
+    auto* remove_old_entry                    = receipt_2.add_state_delta_entries();
+    *remove_old_entry->mutable_object_space() = delta_space;
+    remove_old_entry->set_key( old_order_key );
+
+    auto* remove_transient_entry                    = receipt_2.add_state_delta_entries();
+    *remove_transient_entry->mutable_object_space() = delta_space;
+    remove_transient_entry->set_key( transient_order_key );
+
+    auto* put_final_entry                    = receipt_2.add_state_delta_entries();
+    *put_final_entry->mutable_object_space() = delta_space;
+    put_final_entry->set_key( final_order_key );
+    put_final_entry->set_value( final_order_value );
+
+    _controller.apply_block_delta( block_2, receipt_2, 2 );
+
+    // All three receipt entries, including the absent-key tombstone for the
+    // intermediate ordering key, must contribute to the replayed delta merkle
+    // root. Dropping the tombstone computes a root over one fewer entry and the
+    // next block fails with "block previous state merkle mismatch".
+    BOOST_REQUIRE_EQUAL( util::to_hex( delta_merkle_root( {
+                           { database_key_string( old_order_key ), std::string() },
+                           { database_key_string( transient_order_key ), std::string() },
+                           { database_key_string( final_order_key ), final_order_value }
+    } ) ),
+                         util::to_hex( _controller.get_head_info().head_state_merkle_root() ) );
   }
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -2070,4 +2070,136 @@ BOOST_AUTO_TEST_CASE( apply_block_delta_checked_test )
   }
   KOINOS_CATCH_LOG_AND_RETHROW( info )
 }
+
+BOOST_AUTO_TEST_CASE( rectified_previous_root_test )
+{
+  try
+  {
+    using namespace koinos;
+
+    BOOST_TEST_MESSAGE( "Test the recorded consensus scar of mainnet block 32,789,377" );
+
+    // Mainnet block 32,789,377 (the last block before the January 2026 halt)
+    // has an honest 12-entry delta, but the root signed into block
+    // 32,789,378's header is the 11-entry value computed by the pre-fix
+    // tombstone-dropping replay during the halt recovery. The replayed honest
+    // root must be accepted against the historically signed value - and only
+    // that exact pair.
+    //
+    // The receipt below is the block's real mainnet delta, byte for byte.
+
+    const auto block_id = util::from_hex< std::string >(
+      "0x1220a97d7b0567ad55e3b04446a2bef447335cfd676668b069544b04a4719146d586" );
+    const auto honest_root = util::from_hex< std::string >(
+      "0x12203a22d59290a838dd49c87f57fe80319636950948f6b9aaf02287c03bb36e5f68" );
+    const auto signed_root = util::from_hex< std::string >(
+      "0x12209948b54dee01acd8528cf15dec02366b76e7739aedaf4487859bf6d0d182d690" );
+
+    protocol::block_receipt receipt_1;
+
+    auto add_entry = [ & ]( bool system,
+                            const std::string& zone,
+                            uint32_t space_id,
+                            const std::string& key,
+                            const std::optional< std::string >& value )
+    {
+      auto* entry = receipt_1.add_state_delta_entries();
+      entry->mutable_object_space()->set_system( system );
+      if( zone.size() )
+        entry->mutable_object_space()->set_zone( zone );
+      if( space_id )
+        entry->mutable_object_space()->set_id( space_id );
+      entry->set_key( key );
+      if( value )
+        entry->set_value( *value );
+    };
+
+    add_entry( true, std::string(), 0, util::from_hex< std::string >( "0x1220c8897aa6247e44fabf73270b3264002a9b2fa6654ad7447e3b3f8026ab391b4c" ), util::from_hex< std::string >( "0x0a221220a97d7b0567ad55e3b04446a2bef447335cfd676668b069544b04a4719146d5861293010a22122044622d4cade292dfbf1cc24ba069cd385107997e03fbc7475c5d89069a03a6611081a7d10f18c2c1cf8ebe3322221220e4a6e321d41acff12f3d26fee110c53d92a9efb331547d1fd0d300c6c5d02dac2a221220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8553219000527cd65bc68ac4304b43234714605b954d45023034714e422ba010a5103dd75eddffb5ee7dd390571dbfdd428f530501e8c49a355169121ef2b0e6546bdb75ad290526df1bca61d3632b8bd2c2f2239f8c9b00309ee612f1862fc66dd4045ddbb64265e3bd0441f2cc4779c18301222122000124d8a5dcd089fdbeacac0c5174d5b8024da635be93c3f21f79e924aedf45d1a412058ae0f8bc597905128f00689fe94bfbee728beec97582c5c1496f6bee6e6289d48265ed215ee25709f8d3a5aae3df3f419e77608194bf7d1092741911a76b58e" ) );
+    add_entry( true, util::from_hex< std::string >( "0x002e33fd1aa907b224ce9ce6c94228901d283a02da956da791" ), 0, std::string(), util::from_hex< std::string >( "0x088ec7bf87d7b6d20b" ) );
+    add_entry( true, util::from_hex< std::string >( "0x0069b8719f8b592ae1c3eb8ded2dd4db7c6f915c0cca69e572" ), 0, std::string(), util::from_hex< std::string >( "0x08da9ecb88c0908d03" ) );
+    add_entry( true, util::from_hex< std::string >( "0x00b269e82eb32028cb450f03123e3c4d2f91a7c7ebf4e5bc7c" ), 0, util::from_hex< std::string >( "0x6d61726b657473" ), util::from_hex< std::string >( "0x0a0e08dd86fd841f18b0b50220808020120f08dae8eda4cd0118808010208080401a1308fbb2e091edcf0218e0c2b51b20e0cd8b8901" ) );
+    add_entry( true, util::from_hex< std::string >( "0x002d8960ca118d09aaa2a1d5d25b65d22045f78855e44dd0b1" ), 1, std::string(), util::from_hex< std::string >( "0x0a2212203ffc8ccbcfe6ab5e56ebffc26727a6ba63de1e4797a7faf47c144bfad117d3641210000000000000000001e017454ff4cc2118c2c1cf8ebe332080bcb29fc133" ) );
+    add_entry( true, util::from_hex< std::string >( "0x002e33fd1aa907b224ce9ce6c94228901d283a02da956da791" ), 1, util::from_hex< std::string >( "0x000527cd65bc68ac4304b43234714605b954d45023034714e4" ), util::from_hex< std::string >( "0x08b5c8fbcec6d90110dfba82fcb59d0118c2c1cf8ebe332001" ) );
+    add_entry( true, util::from_hex< std::string >( "0x002e33fd1aa907b224ce9ce6c94228901d283a02da956da791" ), 1, util::from_hex< std::string >( "0x006383c82ba18b95ea6c9581df4b4fe016045a6087ea6ab6ce" ), util::from_hex< std::string >( "0x08edd4d6abbbcd0510edd4d6abbbcd0518c2c1cf8ebe33" ) );
+    add_entry( true, util::from_hex< std::string >( "0x006383c82ba18b95ea6c9581df4b4fe016045a6087ea6ab6ce" ), 1, util::from_hex< std::string >( "0x34" ), util::from_hex< std::string >( "0x08041219007394988c75ad83ba63b339a3318606ea51fbf7107a8b5e6a1a1900347617651ea179eec3998a12f39961294e4eff0ca9fb72b82249566f72746578204272696467653a20506f776572696e67204b6f696e6f7320457870616e73696f6e204163726f73732045564d20616e6420536f6c616e612045636f73797374656d732acb0654686520566f7274657820427269646765207465616d2077696c6c206d61696e7461696e20616e6420657870616e64207468652063726f73732d636861696e20696e66726173747275637475726520636f6e6e656374696e67204b6f696e6f732077697468206d616a6f722065636f73797374656d732c20656e61626c696e6720696e7465726f7065726162696c6974792c206d61726b6574206163636573732c20616e6420757365722067726f777468206f6e20424e4220436861696e20616e6420536f6c616e612e0a0a4f70657261746520616e64206d6f6e69746f7220746865206578697374696e6720457468657265756d20e28694204b6f696e6f7320627269646765207769746820736563757265207472616e73666572732e20457870616e6420746f20424e4220436861696e20616e64206f746865722045564d206e6574776f726b732e20496e74656772617465207769746820536f6c616e61207468726f75676820576f726d686f6c6520746f20737570706f727420764b4f494e20e2869420774b4f494e206272696467696e67207768696c65206c657665726167696e67206578697374696e67206c69717569646974792e2050726f7669646520696e63656e746976657320746f20656e73757265206d61726b657420646570746820616e64207375737461696e61626c652074726164696e672e204f66666572207472616e73706172656e7420616e616c7974696373206f66206c697175696469747920666c6f77732c20766f6c756d65732c20616e6420706572666f726d616e63652e0a0a4c69717569646974792077696c6c206265206465706c6f796564206772616475616c6c7920746f2072656475636520766f6c6174696c6974792c2077697468206d6f6e74686c7920757064617465732e0a0a46756e64696e673a203135302c303030204b4f494e20706572206d6f6e746820666f722034206d6f6e74687320666f7220696e697469616c206c697175696469747920616e6420696e63656e74697665732e204c6174657220706861736573207265717569726520726564756365642066756e64696e6720666f72206d61696e74656e616e63652e20556e75736564206c697175696469747920737461797320696e207468652074726561737572792e3080e0afadc7b4033880d08eeaa2334080d8e190c933480150a0afc8dc9890d8035800580058d8f8b5a5bfedd3025880fcbfa5dffe830158c8bad291fa235800" ) );
+    add_entry( true, util::from_hex< std::string >( "0x006383c82ba18b95ea6c9581df4b4fe016045a6087ea6ab6ce" ), 2, util::from_hex< std::string >( "0x3032303736343330323334323533303630393939393936" ), std::nullopt );
+    add_entry( true, util::from_hex< std::string >( "0x006383c82ba18b95ea6c9581df4b4fe016045a6087ea6ab6ce" ), 2, util::from_hex< std::string >( "0x3032303736343334313930373631313430393939393936" ), std::nullopt );
+    add_entry( true, util::from_hex< std::string >( "0x006383c82ba18b95ea6c9581df4b4fe016045a6087ea6ab6ce" ), 2, util::from_hex< std::string >( "0x3032303736343334333435363239363030393939393936" ), std::string() );
+    add_entry( true, util::from_hex< std::string >( "0x0069b8719f8b592ae1c3eb8ded2dd4db7c6f915c0cca69e572" ), 1, util::from_hex< std::string >( "0x000527cd65bc68ac4304b43234714605b954d45023034714e4" ), util::from_hex< std::string >( "0x08a8e6d2d9869714120d08bed6cb0f10a8e6d2d98697141801" ) );
+
+    auto duration = std::chrono::system_clock::now().time_since_epoch();
+
+    protocol::block block_1;
+    block_1.mutable_header()->set_height( 1 );
+    block_1.mutable_header()->set_previous(
+      util::converter::as< std::string >( crypto::multihash::zero( crypto::multicodec::sha2_256 ) ) );
+    block_1.mutable_header()->set_previous_state_merkle_root(
+      _controller.get_head_info().head_state_merkle_root() );
+    block_1.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() );
+    block_1.set_id( block_id );
+
+    BOOST_TEST_MESSAGE( "Preserve-tombstone replay of the real receipt reproduces the honest root" );
+
+    _controller.apply_block_delta( block_1, receipt_1, 2 );
+    BOOST_REQUIRE_EQUAL( util::to_hex( honest_root ),
+                         util::to_hex( _controller.get_head_info().head_state_merkle_root() ) );
+
+    BOOST_TEST_MESSAGE( "The historically signed root is accepted for the next block" );
+
+    protocol::block block_2;
+    block_2.mutable_header()->set_height( 2 );
+    block_2.mutable_header()->set_previous( block_id );
+    block_2.mutable_header()->set_previous_state_merkle_root( signed_root );
+    block_2.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() + 3'000 );
+    block_2.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_2.header() ) ) );
+
+    protocol::block_receipt receipt_2;
+    auto* put_entry                    = receipt_2.add_state_delta_entries();
+    *put_entry->mutable_object_space() = receipt_1.state_delta_entries( 0 ).object_space();
+    put_entry->set_key( "rectified-root-follow-up" );
+    put_entry->set_value( "value" );
+
+    _controller.apply_block_delta( block_2, receipt_2, 2 );
+    BOOST_CHECK_EQUAL( util::to_hex( block_2.id() ),
+                       util::to_hex( _controller.get_head_info().head_topology().id() ) );
+
+    BOOST_TEST_MESSAGE( "Any other mismatching root still throws" );
+
+    protocol::block block_2b;
+    block_2b.mutable_header()->set_height( 2 );
+    block_2b.mutable_header()->set_previous( block_id );
+    block_2b.mutable_header()->set_previous_state_merkle_root( util::converter::as< std::string >(
+      crypto::hash( crypto::multicodec::sha2_256, "not the signed root"s ) ) );
+    block_2b.mutable_header()->set_timestamp(
+      std::chrono::duration_cast< std::chrono::milliseconds >( duration ).count() + 6'000 );
+    block_2b.set_id(
+      util::converter::as< std::string >( crypto::hash( crypto::multicodec::sha2_256, block_2b.header() ) ) );
+
+    BOOST_CHECK_THROW( _controller.apply_block_delta( block_2b, receipt_2, 2 ),
+                       chain::state_merkle_mismatch_exception );
+
+    BOOST_TEST_MESSAGE( "Checked replay accepts the signed expectation without triggering the fallback" );
+
+    auto replay_dir = std::filesystem::temp_directory_path() / boost::filesystem::unique_path().string();
+    std::filesystem::create_directory( replay_dir );
+    auto replay_controller = std::make_unique< chain::controller >( 10'000'000, 64'000 );
+    replay_controller->open( replay_dir, _genesis_data, chain::fork_resolution_algorithm::fifo, false );
+
+    protocol::block replay_block_1 = block_1;
+    replay_block_1.mutable_header()->set_previous_state_merkle_root(
+      replay_controller->get_head_info().head_state_merkle_root() );
+
+    BOOST_CHECK_EQUAL( false,
+                       replay_controller->apply_block_delta_checked( replay_block_1, receipt_1, signed_root, 2 ) );
+    BOOST_CHECK_EQUAL( util::to_hex( honest_root ),
+                       util::to_hex( replay_controller->get_head_info().head_state_merkle_root() ) );
+
+    replay_controller.reset();
+    std::filesystem::remove_all( replay_dir );
+  }
+  KOINOS_CATCH_LOG_AND_RETHROW( info )
+}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #860

## Summary

Makes a full mainnet sync with `verify-blocks=false` (the default fast receipt-delta replay) complete from genesis to head, correctly and verifiably. Today it silently builds wrong delta roots at a handful of historical blocks and fails far from the cause — the January 2026 `block previous state merkle mismatch` halts at reported heights 30,488,260 / 32,770,790 / 32,789,378 / 32,900,351.

Five commits, reviewable independently:

### 1. Preserve receipt remove tombstones in `apply_block_delta` (25282070)

The root cause of #860. A compacted receipt keeps the remove entry of a key created and removed within the same block. During execution the key existed at the moment of removal, so the consensus root includes its tombstone leaf; during replay the key is absent from the parent, plain `remove_object` no-ops, the leaf is lost, and the replayed root diverges. Replay now uses `remove_object_preserve_tombstone()` (new state-db API). Deterministic tests reproduce the exact failing shape, including the Koinos Fund vote-ordering flow behind the incident.

### 2. Verify state merkle roots during replay (51124213)

`apply_block_delta` previously performed **no** merkle verification, so divergence surfaced only at the first live block after indexing — weeks of sync away from the causal block. It now asserts the header's consensus-signed `previous_state_merkle_root` against the parent node's root before applying entries, and the receipt root (when present) after. Errors become fail-fast at the causal block.

### 3. Checked replay with re-execution fallback (f0711c91, db2e5b4b)

Two historical blocks are irreproducible from their stored receipts under **any** fixed replay semantics:

- **30,504,202** — the 2025-10-31 Koinos Fund rectification block. `maybe_rectify_state` added two entries to the delta (counted by consensus) but the pre-#858 code persisted the *unrectified* receipt, so the stored receipt is missing them. Verified bit-exactly: the root over the 8 stored entries + the 2 rectify.cpp entries equals the signed root.
- Blocks whose receipts a future incident might corrupt similarly.

`apply_block_delta_checked` compares the replayed pending root against the next header's consensus root **before finalizing** (a finalized head node cannot be discarded), and on mismatch discards the still-writable node and re-executes the block through the same internals `submit_block` uses — which re-applies `maybe_rectify_state`, rebuilding the consensus root with no new hardcoded heights. No retry loop: if re-execution cannot reproduce the consensus root either, the sync halts at the causal block. The indexer uses a one-block lookahead so each block is applied when its successor's header (the signed expectation) is known; the final pending block applies unchecked and is cross-checked by the first live block, as today. The `verify-blocks=true` branch is untouched.

### 4. Accept the historically signed root of block 32,789,377 (f9dda073)

The last block before the January 2026 halt. Its honest delta has 12 entries — neighbouring blocks of identical shape (32,789,375/376) prove the network counted such removes, as their signed roots match only with all 12 entries. During the halt recovery, the resuming node computed this block's root with the pre-fix dropping semantics, and that 11-entry root was **signed into block 32,789,378's header**: a permanent consensus scar no honest application can reproduce. Reproducible against any public API node by recomputing the roots from the stored receipt and the next header.

Following the rectify.cpp precedent, `acceptable_rectified_previous_root()` accepts the historically signed value for this exact (parent id, computed root, claimed root) triple — and nothing else — at the three root checks (execution parent assert, replay parent assert, checked-replay expectation). The block's state and receipt remain the honest ones; deliberately NOT forcing an 11-entry delta, since discarding the tombstone would resurrect the removed key in the syncing node's state and diverge it from mainnet. Note this also repairs `verify-blocks=true`: an honest full re-execution sync currently halts at 32,789,378 for the same reason.

The test replays the block's **real mainnet receipt byte-for-byte**, asserting the preserved replay reproduces the honest root, the signed root is accepted for the successor while any other mismatch still throws, and checked replay accepts the expectation without a futile fallback.

## Evidence

- Full-history offline audit: 37,280,004 blocks, 290,295,679 delta entries; preserve-tombstone replay reproduces the signed root chain for 37,280,002 blocks; the two exceptions are the blocks handled above, each verified bit-exactly.
- Analysis, reproduction scripts (including a koilib script that reproduces the 32,789,377 anomaly against `api.koinos.io`), and an operator-facing explainer: [`koinos-one` docs/compatibility](https://github.com/koinos/koinos-one/tree/feat/native-node-version/docs/compatibility).
- A full mainnet resync gate with these changes is in progress; pass criteria: exactly two `delta_replay_fallback` re-executions (30,504,202) / accepted scar (32,789,377), head root equal to the independently audited value.

## Dependencies

Requires the companion koinos-state-db-cpp PR (`remove_object_preserve_tombstone`, `pending_merkle_root`) and a koinos-cmake Hunter pin bump after its release. Local development builds pin a fork tag; the pin bump should land with the release as usual.
